### PR TITLE
Update HomeWidgetExample.swift

### DIFF
--- a/example/ios/HomeWidgetExample/HomeWidgetExample.swift
+++ b/example/ios/HomeWidgetExample/HomeWidgetExample.swift
@@ -44,7 +44,8 @@ struct HomeWidgetExampleEntryView : View {
             Text(entry.title).bold().font(/*@START_MENU_TOKEN@*/.title/*@END_MENU_TOKEN@*/)
             Text(entry.message).font(.body)
         }
-        )}
+        )
+    }
 }
 
 @main


### PR DESCRIPTION
Without this space it will give us a build error on the widget. And it only warns you about the error if you try to resume/view the widget on the preview on XCode. It took me a while to figure this out because I did not try to view in the preview that's why I'm proposing this fix. Btw congrats for your work.