### PR TITLE
Fixes cannot find 'WidgetCenter' in scope error

### DIFF
--- a/ios/Classes/SwiftHomeWidgetPlugin.swift
+++ b/ios/Classes/SwiftHomeWidgetPlugin.swift
@@ -62,7 +62,9 @@ public class SwiftHomeWidgetPlugin: NSObject, FlutterPlugin {
             if let myArgs = args as? [String: Any],
                let name = (myArgs["ios"] ?? myArgs["name"]) as? String{
                 if #available(iOS 14.0, *) {
-                    WidgetCenter.shared.reloadTimelines(ofKind:name)
+                    #if arch(arm64) || arch(i386) || arch(x86_64)
+                        WidgetCenter.shared.reloadTimelines(ofKind:name)
+                    #endif
                 } else {
                     result(FlutterError(code: "-4", message: "Widgets are only available on iOS 14.0 and above", details: nil))
                 }


### PR DESCRIPTION
Hi,

This is a fix for the error: "cannot find 'WidgetCenter' in scope"
It happens when building the app for iOS

This error will not happen on iOS Simulator neither when building to a connected device since it will detect the OS arch and because of that will build correctly.

But when building the IPA for any device. The error will happen. So with this fix we avoid that.

Regards,