### PR TITLE
Fix: avoid collisions with open url methods from other plugins

### DIFF
--- a/ios/Classes/SwiftHomeWidgetPlugin.swift
+++ b/ios/Classes/SwiftHomeWidgetPlugin.swift
@@ -134,8 +134,9 @@ public class SwiftHomeWidgetPlugin: NSObject, FlutterPlugin, FlutterStreamHandle
     public func application(_ application: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
         if(isWidgetUrl(url: url)) {
             latestUrl = url
+            return true
         }
-        return true
+        return false
     }
     
     private func isWidgetUrl(url: URL) -> Bool {


### PR DESCRIPTION
Hello!

Open URL method should return false if the link isn't meant for this plugin, so another plugin can take care of it.

Thank you! 