### PR TITLE
#39 MissingPluginException(No implementation found for method registerBackgroundCallback)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,10 @@ jobs:
       - name: Test
         run: flutter test --coverage
       - uses: VeryGoodOpenSource/very_good_coverage@v1.2.0
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   android:
     name: Android Integration Tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           api-level: 29
           working-directory: example
-          script: flutter drive --driver=test_driver/integration_test.dart --target=integration_test/android_test.dart -d emulator-5554
+          script: flutter test integration_test/android_test.dart -d emulator-5554
 
   # iOS Test based on https://medium.com/flutter-community/run-flutter-driver-tests-on-github-actions-13c639c7e4ab
   # by @kate_sheremet
@@ -83,5 +83,5 @@ jobs:
         with:
           channel: stable
       - name: "Run iOS integration tests"
-        run: flutter drive --driver=test_driver/integration_test.dart --target=integration_test/ios_test.dart -d ${{steps.udid.outputs.UDID}}
+        run: flutter test integration_test/ios_test.dart -d ${{steps.udid.outputs.UDID}}
         working-directory: example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.5
+
+* Fix MissingPluginException for `registerBackgroundCallback` on iOS [#39](https://github.com/ABausG/home_widget/issues/39)
+
 ## 0.1.4
 
 * Fix `HomeWidget.updateWidget` not completing on iOS [#26](https://github.com/ABausG/home_widget/issues/26)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![popularity](https://badges.bar/home_widget/popularity)](https://pub.dev/packages/home_widget/score)
 [![pub points](https://badges.bar/home_widget/pub%20points)](https://pub.dev/packages/home_widget/score)
 [![Build](https://github.com/abausg/home_widget/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/ABausG/home_widget/actions/workflows/main.yml?query=branch%3Amain)
+[![codecov](https://codecov.io/gh/ABausG/home_widget/branch/main/graph/badge.svg?token=ZXTZOL6KFO)](https://codecov.io/gh/ABausG/home_widget)
 
 HomeWidget is a Plugin to make it easier to create HomeScreen Widgets on Android and iOS.
 HomeWidget does **not** allow writing Widgets with Flutter itself. It still requires writing the Widgets with native code. However, it provides a unified Interface for sending data, retrieving data and updating the Widgets

--- a/example/integration_test/ios_test.dart
+++ b/example/integration_test/ios_test.dart
@@ -79,6 +79,19 @@ void main() {
             await HomeWidget.initiallyLaunchedFromHomeWidget();
         expect(retrievedData, isNull);
       });
+
+      group('Register Backgorund Callback', () {
+          testWidgets(
+            'RegisterBackgroundCallback completes without error', (tester) async {
+            await HomeWidget.setAppGroupId('group.es.antonborri.integrationtest');
+            final registerCallbackResult = await HomeWidget.registerBackgroundCallback(backgroundCallback);
+            expect(registerCallbackResult, isNull);
+          }
+          );
+      });
     });
+
   });
 }
+
+void backgroundCallback(Uri uri) {}

--- a/example/integration_test/ios_test.dart
+++ b/example/integration_test/ios_test.dart
@@ -81,16 +81,15 @@ void main() {
       });
 
       group('Register Backgorund Callback', () {
-          testWidgets(
-            'RegisterBackgroundCallback completes without error', (tester) async {
-            await HomeWidget.setAppGroupId('group.es.antonborri.integrationtest');
-            final registerCallbackResult = await HomeWidget.registerBackgroundCallback(backgroundCallback);
-            expect(registerCallbackResult, isNull);
-          }
-          );
+        testWidgets('RegisterBackgroundCallback completes without error',
+            (tester) async {
+          await HomeWidget.setAppGroupId('group.es.antonborri.integrationtest');
+          final registerCallbackResult =
+              await HomeWidget.registerBackgroundCallback(backgroundCallback);
+          expect(registerCallbackResult, isNull);
+        });
       });
     });
-
   });
 }
 

--- a/ios/Classes/SwiftHomeWidgetPlugin.swift
+++ b/ios/Classes/SwiftHomeWidgetPlugin.swift
@@ -105,6 +105,8 @@ public class SwiftHomeWidgetPlugin: NSObject, FlutterPlugin, FlutterStreamHandle
                 return
             }
             result(initialUrl?.absoluteString)
+        } else if call.method == "registerBackgroundCallback" {
+            result(nil)
         } else {
             result(FlutterMethodNotImplemented)
         }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: home_widget
 description: A plugin to provide a common interface for creating HomeScreen Widgets for Android and iOS.
-version: 0.1.4
+version: 0.1.5
 repository: https://github.com/ABausG/home_widget
 
 environment:


### PR DESCRIPTION
Adding a no-op operation on iOS for `registerBackgroundCallback`