### PR TITLE
Allow specification of fully qualified class name for android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.6
+
+* Allow the specification of fully qualified android name 
+
 ## 0.1.5
 
 * Fix MissingPluginException for `registerBackgroundCallback` on iOS [#39](https://github.com/ABausG/home_widget/issues/39)

--- a/README.md
+++ b/README.md
@@ -122,10 +122,12 @@ HomeWidget.updateWidget(
     name: 'HomeWidgetExampleProvider',
     androidName: 'HomeWidgetExampleProvider',
     iOSName: 'HomeWidgetExample',
+    qualifiedAndroidName: 'com.example.app.HomeWidgetExampleProvider',
 );
 ```
 
-The name for Android will be chosen by checking `androidName` if that was not provided it will fallback to `name`.
+The name for Android will be chosen by checking `qualifiedAndroidName`, falling back to `<packageName>.androidName` and if that was not provided it 
+will fallback to `<packageName>.name`.
 This Name needs to be equal to the Classname of the [WidgetProvider](#Write-your-Widget)
 
 The name for iOS will be chosen by checking `iOSName` if that was not provided it will fallback to `name`.

--- a/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetPlugin.kt
+++ b/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetPlugin.kt
@@ -77,9 +77,10 @@ class HomeWidgetPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
                 }
             }
             "updateWidget" -> {
+                val qualifiedName = call.argument<String>("qualifiedAndroidName")
                 val className = call.argument<String>("android") ?: call.argument<String>("name")
                 try {
-                    val javaClass = Class.forName("${context.packageName}.${className}")
+                    val javaClass = Class.forName(qualifiedName ?: "${context.packageName}.${className}")
                     val intent = Intent(context, javaClass)
                     intent.action = AppWidgetManager.ACTION_APPWIDGET_UPDATE
                     val ids: IntArray = AppWidgetManager.getInstance(context.applicationContext).getAppWidgetIds(ComponentName(context, javaClass))

--- a/lib/home_widget.dart
+++ b/lib/home_widget.dart
@@ -22,20 +22,23 @@ class HomeWidget {
 
   /// Updates the HomeScreen Widget
   ///
-  /// Android Widgets will look for [androidName] and then for [name]
+  /// Android Widgets will look for [qualifiedAndroidName] then [androidName] and then for [name]
   /// iOS Widgets will look for [iOSName] and then for [name]
   ///
-  /// The name of the Android Widget must match the classname of the WidgetProvider
+  /// [qualifiedAndroidName] will use the name as is to find the WidgetProvider
+  /// [androidName] must match the classname of the WidgetProvider, prefixed by the package name
   /// The name of the iOS Widget must match the kind specified when creating the Widget
   static Future<bool?> updateWidget({
     String? name,
     String? androidName,
     String? iOSName,
+    String? qualifiedAndroidName,
   }) {
     return _channel.invokeMethod('updateWidget', {
       'name': name,
       'android': androidName,
       'ios': iOSName,
+      'qualifiedAndroidName': qualifiedAndroidName,
     });
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: home_widget
 description: A plugin to provide a common interface for creating HomeScreen Widgets for Android and iOS.
-version: 0.1.5
+version: 0.1.6
 repository: https://github.com/ABausG/home_widget
 
 environment:

--- a/test/home_widget_test.dart
+++ b/test/home_widget_test.dart
@@ -77,6 +77,7 @@ void main() {
         name: 'name',
         androidName: 'androidName',
         iOSName: 'iOSName',
+        qualifiedAndroidName: 'com.example.androidName',
       ),
       true,
     );
@@ -86,6 +87,7 @@ void main() {
     expect(arguments['name'], 'name');
     expect(arguments['android'], 'androidName');
     expect(arguments['ios'], 'iOSName');
+    expect(arguments['qualifiedAndroidName'], 'com.example.androidName');
   });
 
   group('initiallyLaunchedFromHomeWidget', () {

--- a/test/home_widget_test.dart
+++ b/test/home_widget_test.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:typed_data';
 import 'dart:ui';
 
 import 'package:flutter/foundation.dart';


### PR DESCRIPTION
This solves issues created by variants with different applicationIds