### PR TITLE
Change xml paths in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ In order to work correctly there needs to be some platform specific setup. Check
 
 <details><summary>Android</summary>
 
-### Create Widget Layout inside `android/app/res/layout`
+### Create Widget Layout inside `android/app/src/main/res/layout`
 
-### Create Widget Configuration into `android/app/res/xml`
+### Create Widget Configuration into `android/app/src/main/res/xml`
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"


### PR DESCRIPTION
Hello! I have noticed that putting xml files in `android/app/res/layout` and `android/app/res/xml` doesn't work and gradle can't find them. After some research I've found this stackoverflow post about the same error: https://stackoverflow.com/questions/69917184/flutter-androidmanifest-cannot-find-xml-resource

This pull request fixes this, by adding working paths for the platform setup section documentation.