### PR TITLE
Fix xcode creating Widget path

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ For more Information on how to create and configure Android Widgets checkout (ht
 <details><summary>iOS</summary>
 
 ### Add a Widget to your App in Xcode
-Add a widget extension by going `File > Target > Widget Extension`
+Add a widget extension by going `File > New > Target > Widget Extension`
 
 ![Widget Extension](https://github.com/ABausG/home_widget/blob/main/.github/assets/widget_extension.png?raw=true)
 


### PR DESCRIPTION
The path of creating a widget in Xcode might have been changed since writing the original `README`. This is just a small fix for the path to be accurate.

You need to go throw `File > [New] > Target > Widget Extension` to create a widget.

<img width="533" alt="Screen Shot 2022-06-10 at 3 00 18 AM" src="https://user-images.githubusercontent.com/40350360/172964491-e34af408-8ba9-4cdb-b780-caff56682e5e.png">

