### PR TITLE
Add vm-entry to callbackDispatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ With home_widget you can use this by following these steps:
       ...
     }
     ```
+   @pragma('vm:entry-point') must be placed above the callback function to avoid tree shaking in release mode for Android.
+
 5. Register the callback function by calling
     ```dart
     HomeWidget.registerBackgroundCallback(backgroundCallback);

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ With home_widget you can use this by following these steps:
       ...
     }
     ```
-   @pragma('vm:entry-point') must be placed above the callback function to avoid tree shaking in release mode for Android.
+   `@pragma('vm:entry-point')` must be placed above the `callback` function to avoid tree shaking in release mode for Android.
 
 5. Register the callback function by calling
     ```dart

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ With home_widget you can use this by following these steps:
 #### Dart
 4. Write a **static** function that takes a Uri as an argument. This will get called when a user clicks on the View
     ```dart
+    @pragma("vm:entry-point")
     void backgroundCallback(Uri data) {
       // do something with data
       ...

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '10.0'
+platform :ios, '11.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/ios/home_widget.podspec
+++ b/ios/home_widget.podspec
@@ -15,7 +15,7 @@ A new flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.platform = :ios, '8.0'
+  s.platform = :ios, '11.0'
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }

--- a/lib/home_widget_callback_dispatcher.dart
+++ b/lib/home_widget_callback_dispatcher.dart
@@ -4,6 +4,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
 
 /// Dispatcher used for calling dart code from Native Code while in the background
+@pragma("vm:entry-point")
 void callbackDispatcher() {
   const _backgroundChannel = MethodChannel('home_widget/background');
   WidgetsFlutterBinding.ensureInitialized();


### PR DESCRIPTION
As discussed in https://github.com/flutter/flutter/issues/109248

An official document explaining why that vm:entry-point thing is necessary: https://github.com/dart-lang/sdk/blob/master/runtime/docs/compiler/aot/entry_point_pragma.md

This Fixes ABausG/home_widget#96 

Since the app crashes on release mode in flutter 3.3+ and it is not a breaking change, I suggest releasing a new version ASAP