### PR TITLE
annotate callbackDispatcher with @pragma("vm:entry-point")

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:home_widget/home_widget.dart';
 import 'package:workmanager/workmanager.dart';
 
 /// Used for Background Updates using Workmanager Plugin
+@pragma("vm:entry-point")
 void callbackDispatcher() {
   Workmanager().executeTask((taskName, inputData) {
     final now = DateTime.now();


### PR DESCRIPTION
The example is wrong. You get following error if you try to update the widget from the background on Android release mode.

```
E/flutter ( 9318): [ERROR:flutter/runtime/dart_isolate.cc(668)] Could not resolve main entrypoint function.
E/flutter ( 9318): [ERROR:flutter/runtime/dart_isolate.cc(167)] Could not run the run main Dart entrypoint.
E/flutter ( 9318): [ERROR:flutter/runtime/runtime_controller.cc(385)] Could not create root isolate.
E/flutter ( 9318): [ERROR:flutter/shell/common/shell.cc(604)] Could not launch engine with configuration.
```

I've added a @pragma("vm:entry-point") annotation in the example to the callbackDispatcher() function. This change fixes the error.

Can you already say when version 2.0 will be available on pub.dev?