### PR TITLE
Adds support for different layouts when resizing widget (Android)

### DIFF
--- a/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetProvider.kt
+++ b/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetProvider.kt
@@ -13,4 +13,13 @@ abstract class HomeWidgetProvider : AppWidgetProvider() {
     }
 
     abstract fun onUpdate(context: Context, appWidgetManager: AppWidgetManager, appWidgetIds: IntArray, widgetData: SharedPreferences)
+
+    override fun onAppWidgetOptionsChanged(
+        context: Context?,
+        appWidgetManager: AppWidgetManager?,
+        appWidgetId: Int,
+        newOptions: Bundle?
+    ) {
+        super.onAppWidgetOptionsChanged(context, appWidgetManager, appWidgetId, newOptions)
+    }
 }

--- a/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetProvider.kt
+++ b/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetProvider.kt
@@ -4,6 +4,7 @@ import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProvider
 import android.content.Context
 import android.content.SharedPreferences
+import android.os.Bundle
 
 abstract class HomeWidgetProvider : AppWidgetProvider() {
 


### PR DESCRIPTION
Exposes onAppWidgetOptionsChanged so that we can add different layouts when resizing the widget, as per [the documentation](https://developer.android.com/develop/ui/views/appwidgets/layouts).