### PR TITLE
Adds support for toast on widget tap (Android)

### DIFF
--- a/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetBackgroundReceiver.kt
+++ b/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetBackgroundReceiver.kt
@@ -3,6 +3,7 @@ package es.antonborri.home_widget
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.widget.Toast
 import io.flutter.FlutterInjector
 
 class HomeWidgetBackgroundReceiver : BroadcastReceiver() {
@@ -11,5 +12,8 @@ class HomeWidgetBackgroundReceiver : BroadcastReceiver() {
         flutterLoader.startInitialization(context)
         flutterLoader.ensureInitializationComplete(context, null)
         HomeWidgetBackgroundService.enqueueWork(context, intent)
+        if (intent.hasExtra("toast")) {
+            Toast.makeText(context, intent.getStringExtra("toast"), Toast.LENGTH_SHORT).show();
+        }
     }
 }

--- a/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetIntent.kt
+++ b/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetIntent.kt
@@ -29,10 +29,14 @@ object HomeWidgetLaunchIntent {
 object HomeWidgetBackgroundIntent {
     private const val HOME_WIDGET_BACKGROUND_ACTION = "es.antonborri.home_widget.action.BACKGROUND"
 
-    fun getBroadcast(context: Context, uri: Uri? = null): PendingIntent {
+    @JvmOverloads
+    fun getBroadcast(context: Context, uri: Uri? = null, toast: String? = null): PendingIntent {
         val intent = Intent(context, HomeWidgetBackgroundReceiver::class.java)
         intent.data = uri
         intent.action = HOME_WIDGET_BACKGROUND_ACTION
+        if (toast != null) {
+            intent.putExtra("toast", toast)
+        }
 
         var flags = PendingIntent.FLAG_UPDATE_CURRENT
         if (Build.VERSION.SDK_INT >= 23) {

--- a/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetProvider.kt
+++ b/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetProvider.kt
@@ -4,7 +4,6 @@ import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProvider
 import android.content.Context
 import android.content.SharedPreferences
-import android.os.Bundle
 
 abstract class HomeWidgetProvider : AppWidgetProvider() {
 
@@ -14,13 +13,4 @@ abstract class HomeWidgetProvider : AppWidgetProvider() {
     }
 
     abstract fun onUpdate(context: Context, appWidgetManager: AppWidgetManager, appWidgetIds: IntArray, widgetData: SharedPreferences)
-
-    override fun onAppWidgetOptionsChanged(
-        context: Context?,
-        appWidgetManager: AppWidgetManager?,
-        appWidgetId: Int,
-        newOptions: Bundle?
-    ) {
-        super.onAppWidgetOptionsChanged(context, appWidgetManager, appWidgetId, newOptions)
-    }
 }

--- a/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetProvider.kt
+++ b/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetProvider.kt
@@ -13,4 +13,13 @@ abstract class HomeWidgetProvider : AppWidgetProvider() {
     }
 
     abstract fun onUpdate(context: Context, appWidgetManager: AppWidgetManager, appWidgetIds: IntArray, widgetData: SharedPreferences)
+
+    override fun onAppWidgetOptionsChanged(
+        context: Context?,
+        appWidgetManager: AppWidgetManager?,
+        appWidgetId: Int,
+        newOptions: Bundle?
+    ) {
+        super.onAppWidgetOptionsChanged(context, appWidgetManager, appWidgetId, newOptions)
+    }
 }

--- a/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetProvider.kt
+++ b/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetProvider.kt
@@ -4,6 +4,7 @@ import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProvider
 import android.content.Context
 import android.content.SharedPreferences
+import android.os.Bundle
 
 abstract class HomeWidgetProvider : AppWidgetProvider() {
 


### PR DESCRIPTION
Add supports to show a native Android toast when tapping a widget (while still supporting the broadcast back to out app).

Example: tapping a "reload" icon will send a "reload-clicked" broadcast back to our app (so that we can update the widget or do whatever we please with it), and show a Toast with the test "Reloading..." at the same time.

```
PendingIntent reloadIntent = HomeWidgetBackgroundIntent.INSTANCE.getBroadcast(context, Uri.parse("homeWidgetExample://reload-clicked"), "Reloading...");
        
view.setOnClickPendingIntent(R.id.widget_icon_reload, reloadIntent);
```

![imagen](https://user-images.githubusercontent.com/4816367/229116850-85dd618b-649f-47fc-a0da-c53f25d458b8.png)

