### PR TITLE
Fix using SharedPreferences in overriden onDeleted method for Android

### DIFF
--- a/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetProvider.kt
+++ b/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetProvider.kt
@@ -13,4 +13,11 @@ abstract class HomeWidgetProvider : AppWidgetProvider() {
     }
 
     abstract fun onUpdate(context: Context, appWidgetManager: AppWidgetManager, appWidgetIds: IntArray, widgetData: SharedPreferences)
+
+    override fun onDeleted(context: Context, appWidgetIds: IntArray) {
+        super.onDeleted(context, appWidgetIds)
+        onDeleted(context, appWidgetIds, HomeWidgetPlugin.getData(context))
+    }
+
+    abstract fun onDeleted(context: Context, appWidgetIds: IntArray, widgetData: SharedPreferences)
 }

--- a/example/android/app/src/main/kotlin/es/antonborri/home_widget_example/HomeWidgetExampleProvider.kt
+++ b/example/android/app/src/main/kotlin/es/antonborri/home_widget_example/HomeWidgetExampleProvider.kt
@@ -31,7 +31,7 @@ class HomeWidgetExampleProvider : HomeWidgetProvider() {
                 )
                 setOnClickPendingIntent(R.id.widget_title, backgroundIntent)
 
-                val message = widgetData.getString("message$widgetId", null)
+                val message = widgetData.getString("message", null)
                 setTextViewText(R.id.widget_message, message
                         ?: "No Message Set")
                 // Show Images saved with `renderFlutterWidget`

--- a/example/android/app/src/main/kotlin/es/antonborri/home_widget_example/HomeWidgetExampleProvider.kt
+++ b/example/android/app/src/main/kotlin/es/antonborri/home_widget_example/HomeWidgetExampleProvider.kt
@@ -31,7 +31,7 @@ class HomeWidgetExampleProvider : HomeWidgetProvider() {
                 )
                 setOnClickPendingIntent(R.id.widget_title, backgroundIntent)
 
-                val message = widgetData.getString("message", null)
+                val message = widgetData.getString("message$widgetId", null)
                 setTextViewText(R.id.widget_message, message
                         ?: "No Message Set")
                 // Show Images saved with `renderFlutterWidget`
@@ -43,6 +43,9 @@ class HomeWidgetExampleProvider : HomeWidgetProvider() {
                     setViewVisibility(R.id.widget_img, View.GONE)
                 }
 
+                // Create a unique key
+                val message = widgetData.getString("unique$widgetId", null)
+
                 // Detect App opened via Click inside Flutter
                 val pendingIntentWithData = HomeWidgetLaunchIntent.getActivity(
                         context,
@@ -52,6 +55,16 @@ class HomeWidgetExampleProvider : HomeWidgetProvider() {
             }
 
             appWidgetManager.updateAppWidget(widgetId, views)
+        }
+    }
+
+    override fun onDeleted(context: Context, appWidgetIds: IntArray, widgetData: SharedPreferences) {
+        // Deletes orphaned keys
+        appWidgetIds.forEach { widgetId ->
+            val editor = widgetData.edit()
+            editor.remove("unique$widgetId")
+            editor.apply()
+            println("deleted!")
         }
     }
 }

--- a/example/android/app/src/main/kotlin/es/antonborri/home_widget_example/HomeWidgetExampleProvider.kt
+++ b/example/android/app/src/main/kotlin/es/antonborri/home_widget_example/HomeWidgetExampleProvider.kt
@@ -44,7 +44,7 @@ class HomeWidgetExampleProvider : HomeWidgetProvider() {
                 }
 
                 // Create a unique key
-                val message = widgetData.getString("unique$widgetId", null)
+                val unique = widgetData.getString("unique$widgetId", null)
 
                 // Detect App opened via Click inside Flutter
                 val pendingIntentWithData = HomeWidgetLaunchIntent.getActivity(


### PR DESCRIPTION
Allows the ability to create unique key values for each widget instance, based on widgetId.
The onDeleted method is needed to clear orphaned keys when the widget is deleted from home screen.
Example on usage is provided.