### PR TITLE
fix: First event being missed in iOS background worker

### DIFF
--- a/ios/Classes/HomeWidgetBackgroundWorker.swift
+++ b/ios/Classes/HomeWidgetBackgroundWorker.swift
@@ -32,12 +32,12 @@ public struct HomeWidgetBackgroundWorker {
   static public func run(url: URL?, appGroup: String) async {
     if isSetupCompleted {
       let preferences = UserDefaults.init(suiteName: appGroup)
-
       let dispatcher = preferences?.object(forKey: dispatcherKey) as! Int64
       NSLog("Dispatcher: \(dispatcher)")
-      queue.append((url, appGroup))
-    } else {
+
       await sendEvent(url: url, appGroup: appGroup)
+    } else {
+      queue.append((url, appGroup))
     }
   }
 


### PR DESCRIPTION
I noticed a problem with the execution of the `HomeWidgetBackgroundWorker`. The first tap on my widget's button wouldn't execute the Dart callback the first time it had been called (with the app being terminated). I believe the if condition in `run` should be the other way around:
- if the setup is completed and the `FlutterEngine` is started we can send the event directly to the `MethodChannel`.
- if the setup is not yet completed we should add the event to the queue and when the background is initialized (`HomeWidget.backgroundInitialized` is received) the queue will be emptied and the event send to the existing method channel.

I'm also not sure if we need to get the dispatcher here and log it, but I leave it for you to decide.