### PR TITLE
feat: support Uint8List as FlutterStandardTypedData on iOS

### DIFF
--- a/example/integration_test/ios_test.dart
+++ b/example/integration_test/ios_test.dart
@@ -23,6 +23,7 @@ void main() {
       'boolKey': true,
       'floatingNumberKey': 12.1,
       'nullValueKey': null,
+      'uint8ListKey': Uint8List.fromList([]),
     };
 
     const defaultValue = MapEntry('defaultKey', 'defaultValue');

--- a/ios/Classes/SwiftHomeWidgetPlugin.swift
+++ b/ios/Classes/SwiftHomeWidgetPlugin.swift
@@ -63,7 +63,11 @@ public class SwiftHomeWidgetPlugin: NSObject, FlutterPlugin, FlutterStreamHandle
       {
         let preferences = UserDefaults.init(suiteName: SwiftHomeWidgetPlugin.groupId)
         if data != nil {
-          preferences?.setValue(data, forKey: id)
+          if let binaryData = data as? FlutterStandardTypedData {
+            preferences?.setValue(Data(binaryData.data), forKey: id)
+          } else {
+            preferences?.setValue(data, forKey: id)
+          }
         } else {
           preferences?.removeObject(forKey: id)
         }


### PR DESCRIPTION
Thanks for this awesome package.

This PR adds support for Uint8List, Int32List, Int64List, Float64List. The StandardMessageCodec encodes them to FlutterStandardTypedData in Swift. Passing this type of data to UserDefaults.SetValue results in a runtime crash.

I added a special case to extract the data and cast it to the built-in type `Data`. With this small change saving the data to UserDefaults completes successfully. 