### PR TITLE
fix: Android 14+ launch support

### DIFF
--- a/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetIntent.kt
+++ b/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetIntent.kt
@@ -1,6 +1,7 @@
 package es.antonborri.home_widget
 
 import android.app.Activity
+import android.app.ActivityOptions
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
@@ -21,7 +22,14 @@ object HomeWidgetLaunchIntent {
             flags = flags or PendingIntent.FLAG_IMMUTABLE
         }
 
-        return PendingIntent.getActivity(context, 0, intent, flags)
+        if (Build.VERSION.SDK_INT < 34) {
+            return PendingIntent.getActivity(context, 0, intent, flags)
+        }
+
+        val options = ActivityOptions.makeBasic()
+        options.pendingIntentBackgroundActivityStartMode = ActivityOptions.MODE_BACKGROUND_ACTIVITY_START_ALLOWED
+
+        return PendingIntent.getActivity(context, 0, intent, flags, options.toBundle())
     }
 }
 


### PR DESCRIPTION
Launching an app on Android 14+ requires an additional option to be passed to `PendingIntent`. More information can be found here: https://developer.android.com/guide/components/activities/background-starts