### PR TITLE
fix: addApplicationDelegate unavailable in iOS

### DIFF
--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>11.0</string>
+  <string>12.0</string>
 </dict>
 </plist>

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '11.0'
+# platform :ios, '12.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
@@ -32,20 +32,20 @@ target 'Runner' do
   use_modular_headers!
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
-end
 
-target 'RunnerTests' do
-  use_frameworks!
-  use_modular_headers!
+  target 'RunnerTests' do
+    use_frameworks!
+    use_modular_headers!
+    inherit! :search_paths
+  end
 
-  inherit! :search_paths
-end
+  target 'HomeWidgetExampleExtension' do
+    use_frameworks!
+    use_modular_headers!
+    inherit! :search_paths
 
-target 'HomeWidgetExampleExtension' do
-  use_frameworks!
-  use_modular_headers!
-
-  pod 'home_widget', :path => '.symlinks/plugins/home_widget/ios'
+    pod 'home_widget', :path => '.symlinks/plugins/home_widget/ios'
+  end
 end
 
 post_install do |installer|

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -32,12 +32,20 @@ target 'Runner' do
   use_modular_headers!
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
-  target 'RunnerTests' do
-    inherit! :search_paths
-  end
-  target 'HomeWidgetExampleExtension' do
-    inherit! :search_paths
-  end
+end
+
+target 'RunnerTests' do
+  use_frameworks!
+  use_modular_headers!
+
+  inherit! :search_paths
+end
+
+target 'HomeWidgetExampleExtension' do
+  use_frameworks!
+  use_modular_headers!
+
+  pod 'home_widget', :path => '.symlinks/plugins/home_widget/ios'
 end
 
 post_install do |installer|

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -7,10 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0B60E2F626215A06337D8571 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6F8D8DC039493B5AFB74B01F /* Pods_RunnerTests.framework */; };
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		16A8E8DE0722EAA17C744601 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63BD42C9386CBFE26633ADC6 /* Pods_Runner.framework */; };
+		210330D7029BCA831D038C2B /* Pods_HomeWidgetExampleExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D63E75043F62B87E3037F606 /* Pods_HomeWidgetExampleExtension.framework */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
-		3767795F3957A9DD7F9FD47A /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 782E23792C4AD1515728BC69 /* Pods_RunnerTests.framework */; };
 		3AAC6A3C2B1CD43700ED5F59 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AAC6A3B2B1CD43700ED5F59 /* WidgetKit.framework */; };
 		3AAC6A3E2B1CD43700ED5F59 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AAC6A3D2B1CD43700ED5F59 /* SwiftUI.framework */; };
 		3AAC6A432B1CD43700ED5F59 /* HomeWidgetExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AAC6A422B1CD43700ED5F59 /* HomeWidgetExample.swift */; };
@@ -19,7 +20,6 @@
 		3AAC6A502B1CD45700ED5F59 /* BackgroundIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AAC6A4F2B1CD45700ED5F59 /* BackgroundIntent.swift */; };
 		3AAC6A512B1CD45700ED5F59 /* BackgroundIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AAC6A4F2B1CD45700ED5F59 /* BackgroundIntent.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
-		7080E8EEB234A16B671090D2 /* Pods_HomeWidgetExampleExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E5C99A981C1592642E9F3DAA /* Pods_HomeWidgetExampleExtension.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
@@ -84,12 +84,13 @@
 		3AAC6A4F2B1CD45700ED5F59 /* BackgroundIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundIntent.swift; sourceTree = "<group>"; };
 		3AAC6A522B1CD46500ED5F59 /* HomeWidgetExampleExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = HomeWidgetExampleExtension.entitlements; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		3BF80489BB85E14581A5B18B /* Pods-Runner-HomeWidgetExampleExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner-HomeWidgetExampleExtension.debug.xcconfig"; path = "Target Support Files/Pods-Runner-HomeWidgetExampleExtension/Pods-Runner-HomeWidgetExampleExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		63BD42C9386CBFE26633ADC6 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		67B96C62570AB0F95CEB9857 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		6AC96EF63E75CCC1A8FD0DAE /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		6F8D8DC039493B5AFB74B01F /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		782E23792C4AD1515728BC69 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
@@ -99,10 +100,12 @@
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AB4991BB2F6104F16A20FAFF /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		B0A07594AFEF926462E78D37 /* Pods-Runner-HomeWidgetExampleExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner-HomeWidgetExampleExtension.release.xcconfig"; path = "Target Support Files/Pods-Runner-HomeWidgetExampleExtension/Pods-Runner-HomeWidgetExampleExtension.release.xcconfig"; sourceTree = "<group>"; };
 		C1463ED1DE22ED64431F627A /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		C1F2EEA684896C2FE30BA404 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		C52AF632B32B3D977D171253 /* Pods-HomeWidgetExampleExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HomeWidgetExampleExtension.debug.xcconfig"; path = "Target Support Files/Pods-HomeWidgetExampleExtension/Pods-HomeWidgetExampleExtension.debug.xcconfig"; sourceTree = "<group>"; };
-		E5C99A981C1592642E9F3DAA /* Pods_HomeWidgetExampleExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HomeWidgetExampleExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D63E75043F62B87E3037F606 /* Pods_HomeWidgetExampleExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HomeWidgetExampleExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E4FA7311A3046643090E4405 /* Pods-Runner-HomeWidgetExampleExtension.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner-HomeWidgetExampleExtension.profile.xcconfig"; path = "Target Support Files/Pods-Runner-HomeWidgetExampleExtension/Pods-Runner-HomeWidgetExampleExtension.profile.xcconfig"; sourceTree = "<group>"; };
 		E83E2772F8C2648F6A4B8430 /* Pods-HomeWidgetExampleExtension.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HomeWidgetExampleExtension.profile.xcconfig"; path = "Target Support Files/Pods-HomeWidgetExampleExtension/Pods-HomeWidgetExampleExtension.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -113,7 +116,7 @@
 			files = (
 				3AAC6A3E2B1CD43700ED5F59 /* SwiftUI.framework in Frameworks */,
 				3AAC6A3C2B1CD43700ED5F59 /* WidgetKit.framework in Frameworks */,
-				7080E8EEB234A16B671090D2 /* Pods_HomeWidgetExampleExtension.framework in Frameworks */,
+				210330D7029BCA831D038C2B /* Pods_HomeWidgetExampleExtension.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -121,7 +124,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3767795F3957A9DD7F9FD47A /* Pods_RunnerTests.framework in Frameworks */,
+				0B60E2F626215A06337D8571 /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -149,9 +152,9 @@
 			children = (
 				3AAC6A3B2B1CD43700ED5F59 /* WidgetKit.framework */,
 				3AAC6A3D2B1CD43700ED5F59 /* SwiftUI.framework */,
-				E5C99A981C1592642E9F3DAA /* Pods_HomeWidgetExampleExtension.framework */,
 				63BD42C9386CBFE26633ADC6 /* Pods_Runner.framework */,
-				782E23792C4AD1515728BC69 /* Pods_RunnerTests.framework */,
+				D63E75043F62B87E3037F606 /* Pods_HomeWidgetExampleExtension.framework */,
+				6F8D8DC039493B5AFB74B01F /* Pods_RunnerTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -230,6 +233,9 @@
 				01ED8F3E7A1B3BBE2ED10AB6 /* Pods-RunnerTests.debug.xcconfig */,
 				AB4991BB2F6104F16A20FAFF /* Pods-RunnerTests.release.xcconfig */,
 				C1F2EEA684896C2FE30BA404 /* Pods-RunnerTests.profile.xcconfig */,
+				3BF80489BB85E14581A5B18B /* Pods-Runner-HomeWidgetExampleExtension.debug.xcconfig */,
+				B0A07594AFEF926462E78D37 /* Pods-Runner-HomeWidgetExampleExtension.release.xcconfig */,
+				E4FA7311A3046643090E4405 /* Pods-Runner-HomeWidgetExampleExtension.profile.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -306,7 +312,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1500;
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					331C8080294A63A400263BE5 = {
@@ -592,7 +598,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -848,7 +854,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -897,7 +903,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ios/Classes/SwiftHomeWidgetPlugin.swift
+++ b/ios/Classes/SwiftHomeWidgetPlugin.swift
@@ -20,6 +20,12 @@ public class SwiftHomeWidgetPlugin: NSObject, FlutterPlugin, FlutterStreamHandle
   private let notInitializedError = FlutterError(
     code: "-7", message: "AppGroupId not set. Call setAppGroupId first", details: nil)
 
+  private static func isRunningInAppExtension() -> Bool {
+    let bundleURL = Bundle.main.bundleURL
+    let bundlePathExtension = bundleURL.pathExtension
+    return bundlePathExtension == "appex"
+  }
+
   public static func register(with registrar: FlutterPluginRegistrar) {
     let instance = SwiftHomeWidgetPlugin()
 
@@ -30,7 +36,14 @@ public class SwiftHomeWidgetPlugin: NSObject, FlutterPlugin, FlutterStreamHandle
       name: "home_widget/updates", binaryMessenger: registrar.messenger())
     eventChannel.setStreamHandler(instance)
 
-    registrar.addApplicationDelegate(instance)
+    guard isRunningInAppExtension() == false else {
+      return
+    }
+
+    let selector = NSSelectorFromString("addApplicationDelegate:")
+    if registrar.responds(to: selector) {
+      registrar.perform(selector, with: instance)
+    }
   }
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {


### PR DESCRIPTION
I'm proposing a simple fix to avoid errors caused by `NS_EXTENSION_UNAVAILABLE_IOS` when adding `home_widget` to the widget target. This fix uses `performSelector` to bypass the `NS_EXTENSION_UNAVAILABLE_IOS` macro. It might not be ideal, but it works and is very simple.