### PR TITLE
fix: HomeWidgetBackgroundWorker on iOS not setting Setup as completed

### DIFF
--- a/ios/Classes/HomeWidgetBackgroundWorker.swift
+++ b/ios/Classes/HomeWidgetBackgroundWorker.swift
@@ -68,8 +68,8 @@ public struct HomeWidgetBackgroundWorker {
   public static func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
     switch call.method {
     case "HomeWidget.backgroundInitialized":
+      isSetupCompleted = true
       while !queue.isEmpty {
-        isSetupCompleted = true
         let entry = queue.removeFirst()
         Task {
           await sendEvent(url: entry.0, appGroup: entry.1)


### PR DESCRIPTION
On iOS, the `HomeWidgetBackgroundWorker` doesn't function because the `isSetupCompleted` flag is always false. This happens because `isSetupCompleted` is set to `true` only when the `backgroundInitialized` callback runs after the first event is added to the queue, which happens rarely. To fix it, simply move `isSetupCompleted` outside the `while` loop.