### PR TITLE
Fix: iOS background worker

### DIFF
--- a/ios/Classes/HomeWidgetBackgroundWorker.swift
+++ b/ios/Classes/HomeWidgetBackgroundWorker.swift
@@ -91,8 +91,10 @@ public struct HomeWidgetBackgroundWorker {
       return
     }
     await withCheckedContinuation { continuation in
-      _channel.invokeMethod("", arguments: [_callback, url?.absoluteString]) { _ in
-        continuation.resume()
+      DispatchQueue.main.async {
+        _channel.invokeMethod("", arguments: [_callback, url?.absoluteString]) { _ in
+          continuation.resume()
+        }
       }
     }
   }

--- a/ios/Classes/HomeWidgetBackgroundWorker.swift
+++ b/ios/Classes/HomeWidgetBackgroundWorker.swift
@@ -83,16 +83,17 @@ public struct HomeWidgetBackgroundWorker {
   }
 
   static func sendEvent(url: URL?, appGroup: String) async {
-    DispatchQueue.main.async {
-      let preferences = UserDefaults.init(suiteName: appGroup)
-      let callback = preferences?.object(forKey: callbackKey) as! Int64
-
-      channel?.invokeMethod(
-        "",
-        arguments: [
-          callback,
-          url?.absoluteString,
-        ])
+    guard let _channel = channel else {
+      return
+    }
+    let preferences = UserDefaults.init(suiteName: appGroup)
+    guard let _callback = preferences?.object(forKey: callbackKey) as? Int64 else {
+      return
+    }
+    await withCheckedContinuation { continuation in
+      _channel.invokeMethod("", arguments: [_callback, url?.absoluteString]) { _ in
+        continuation.resume()
+      }
     }
   }
 }

--- a/ios/Classes/HomeWidgetBackgroundWorker.swift
+++ b/ios/Classes/HomeWidgetBackgroundWorker.swift
@@ -15,10 +15,11 @@ public struct HomeWidgetBackgroundWorker {
   static let dispatcherKey: String = "home_widget.internal.background.dispatcher"
   static let callbackKey: String = "home_widget.internal.background.callback"
 
-  static var isSetupCompleted: Bool = false
   static var engine: FlutterEngine?
   static var channel: FlutterMethodChannel?
-  static var queue: [(URL?, String)] = []
+
+  static var isSetupCompleted: Bool = false
+  static var continuations: [CheckedContinuation<Void, Never>] = []
 
   private static var registerPlugins: FlutterPluginRegistrantCallback?
 
@@ -30,15 +31,17 @@ public struct HomeWidgetBackgroundWorker {
   /// The url you provide will be used as arguments in the callback function in dart
   /// The AppGroup is necessary to retrieve the dart callbacks
   static public func run(url: URL?, appGroup: String) async {
-    if isSetupCompleted {
-      let preferences = UserDefaults.init(suiteName: appGroup)
-      let dispatcher = preferences?.object(forKey: dispatcherKey) as! Int64
-      NSLog("Dispatcher: \(dispatcher)")
-
-      await sendEvent(url: url, appGroup: appGroup)
-    } else {
-      queue.append((url, appGroup))
+    if isSetupCompleted == false {
+      await withCheckedContinuation { continuation in
+        continuations.append(continuation)
+      }
     }
+
+    let preferences = UserDefaults.init(suiteName: appGroup)
+    let dispatcher = preferences?.object(forKey: dispatcherKey) as! Int64
+    NSLog("Dispatcher: \(dispatcher)")
+
+    await sendEvent(url: url, appGroup: appGroup)
   }
 
   static func setupEngine(dispatcher: Int64) {
@@ -69,11 +72,9 @@ public struct HomeWidgetBackgroundWorker {
     switch call.method {
     case "HomeWidget.backgroundInitialized":
       isSetupCompleted = true
-      while !queue.isEmpty {
-        let entry = queue.removeFirst()
-        Task {
-          await sendEvent(url: entry.0, appGroup: entry.1)
-        }
+      while !continuations.isEmpty {
+        let continuation = continuations.removeFirst()
+        continuation.resume()
       }
       result(true)
     default:


### PR DESCRIPTION
There is an issue with how `HomeWidgetBackgroundWorker` uses `async/await` in its iOS implementation. Currently, the `run` method returns immediately, before the platform channel can be initialized and the Flutter callback performed.

I've refactored the `HomeWidgetBackgroundWorker` with a proper `async/await` implementation. Now, the `run` method will return only after the interactivity callback in Flutter has been executed.