### PR TITLE
refactor: Update main.dart layout to use SingleChildScrollView for be…

### DIFF
--- a/packages/home_widget/example/lib/main.dart
+++ b/packages/home_widget/example/lib/main.dart
@@ -248,58 +248,61 @@ class _MyAppState extends State<MyApp> {
       appBar: AppBar(
         title: const Text('HomeWidget Example'),
       ),
-      body: Center(
-        child: Padding(
-          padding: const EdgeInsets.all(16.0),
-          child: Column(
-            children: [
-              TextField(
-                decoration: const InputDecoration(
-                  hintText: 'Title',
-                ),
-                controller: _titleController,
-              ),
-              TextField(
-                decoration: const InputDecoration(
-                  hintText: 'Body',
-                ),
-                controller: _messageController,
-              ),
-              ElevatedButton(
-                onPressed: _sendAndUpdate,
-                child: const Text('Send Data to Widget'),
-              ),
-              ElevatedButton(
-                onPressed: _loadData,
-                child: const Text('Load Data'),
-              ),
-              ElevatedButton(
-                onPressed: _checkForWidgetLaunch,
-                child: const Text('Check For Widget Launch'),
-              ),
-              if (Platform.isAndroid)
-                ElevatedButton(
-                  onPressed: _startBackgroundUpdate,
-                  child: const Text('Update in background'),
-                ),
-              if (Platform.isAndroid)
-                ElevatedButton(
-                  onPressed: _stopBackgroundUpdate,
-                  child: const Text('Stop updating in background'),
-                ),
-              ElevatedButton(
-                onPressed: _getInstalledWidgets,
-                child: const Text('Get Installed Widgets'),
-              ),
-              if (_isRequestPinWidgetSupported)
-                ElevatedButton(
-                  onPressed: () => HomeWidget.requestPinWidget(
-                    qualifiedAndroidName:
-                        'es.antonborri.home_widget_example.glance.HomeWidgetReceiver',
+      body: SingleChildScrollView(
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              children: [
+                TextField(
+                  decoration: const InputDecoration(
+                    hintText: 'Title',
                   ),
-                  child: const Text('Pin Widget'),
+                  controller: _titleController,
                 ),
-            ],
+                TextField(
+                  decoration: const InputDecoration(
+                    hintText: 'Body',
+                  ),
+                  controller: _messageController,
+                ),
+                const SizedBox(height: 10),
+                ElevatedButton(
+                  onPressed: _sendAndUpdate,
+                  child: const Text('Send Data to Widget'),
+                ),
+                ElevatedButton(
+                  onPressed: _loadData,
+                  child: const Text('Load Data'),
+                ),
+                ElevatedButton(
+                  onPressed: _checkForWidgetLaunch,
+                  child: const Text('Check For Widget Launch'),
+                ),
+                if (Platform.isAndroid)
+                  ElevatedButton(
+                    onPressed: _startBackgroundUpdate,
+                    child: const Text('Update in background'),
+                  ),
+                if (Platform.isAndroid)
+                  ElevatedButton(
+                    onPressed: _stopBackgroundUpdate,
+                    child: const Text('Stop updating in background'),
+                  ),
+                ElevatedButton(
+                  onPressed: _getInstalledWidgets,
+                  child: const Text('Get Installed Widgets'),
+                ),
+                if (_isRequestPinWidgetSupported)
+                  ElevatedButton(
+                    onPressed: () => HomeWidget.requestPinWidget(
+                      qualifiedAndroidName:
+                          'es.antonborri.home_widget_example.glance.HomeWidgetReceiver',
+                    ),
+                    child: const Text('Pin Widget'),
+                  ),
+              ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
This pull request includes changes to the user interface in the `packages/home_widget/example/lib/main.dart` file to improve the layout and spacing of the HomeWidget example application. The most important changes include wrapping the `body` in a `SingleChildScrollView`, adding a `SizedBox` for spacing, and ensuring proper nesting of widgets.

Improvements to layout and spacing:

* Wrapped the `body` in a `SingleChildScrollView` to allow for scrolling when content overflows the screen. [[1]](diffhunk://#diff-c068dca4a17f9111e25b3da086952a2cb9b867be6fa21928fdcf5c983148d79cL251-R252) [[2]](diffhunk://#diff-c068dca4a17f9111e25b3da086952a2cb9b867be6fa21928fdcf5c983148d79cR308)
* Added a `SizedBox` with a height of 10 pixels between the `TextField` and `ElevatedButton` to improve spacing.

<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
Replace this text.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation and added code (documentation) comments where necessary.
- [ ] I have updated/added relevant examples in `example` or documentation.


## Breaking Change?
<!--
Would your PR require home_widget users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [ ] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version below:
-->


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/abausg/home_widget/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->