### PR TITLE
fix(ios): Properly serialize arrays of Codable objects in widget config

### DIFF
--- a/packages/home_widget/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetBackgroundReceiver.kt
+++ b/packages/home_widget/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetBackgroundReceiver.kt
@@ -10,6 +10,7 @@ class HomeWidgetBackgroundReceiver : BroadcastReceiver() {
     val flutterLoader = FlutterInjector.instance().flutterLoader()
     flutterLoader.startInitialization(context)
     flutterLoader.ensureInitializationComplete(context, null)
-    HomeWidgetBackgroundWorker.enqueueWork(context, intent)
+    val expedited = intent.getBooleanExtra(HomeWidgetBackgroundIntent.EXTRA_IS_EXPEDITED, false)
+    HomeWidgetBackgroundWorker.enqueueWork(context, intent, expedited)
   }
 }

--- a/packages/home_widget/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetBackgroundWorker.kt
+++ b/packages/home_widget/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetBackgroundWorker.kt
@@ -9,6 +9,7 @@ import androidx.work.CoroutineWorker
 import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import io.flutter.FlutterInjector
@@ -111,11 +112,17 @@ class HomeWidgetBackgroundWorker(private val context: Context, workerParams: Wor
     private val serviceStarted = AtomicBoolean(false)
     private val mainHandler = Handler(Looper.getMainLooper())
 
-    fun enqueueWork(context: Context, work: Intent) {
+    fun enqueueWork(context: Context, work: Intent, expedited: Boolean = false) {
       val data = Data.Builder().putString(DATA_KEY, work.data?.toString() ?: "").build()
 
-      val workRequest =
-          OneTimeWorkRequestBuilder<HomeWidgetBackgroundWorker>().setInputData(data).build()
+      val workRequestBuilder = OneTimeWorkRequestBuilder<HomeWidgetBackgroundWorker>()
+          .setInputData(data)
+
+      if (expedited) {
+        workRequestBuilder.setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+      }
+
+      val workRequest = workRequestBuilder.build()
 
       WorkManager.getInstance(context)
           .enqueueUniqueWork(UNIQUE_WORK_NAME, ExistingWorkPolicy.APPEND, workRequest)

--- a/packages/home_widget/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetIntent.kt
+++ b/packages/home_widget/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetIntent.kt
@@ -53,11 +53,13 @@ inline fun <reified T : Activity> actionStartActivity(context: Context, uri: Uri
 
 object HomeWidgetBackgroundIntent {
   private const val HOME_WIDGET_BACKGROUND_ACTION = "es.antonborri.home_widget.action.BACKGROUND"
+  const val EXTRA_IS_EXPEDITED = "es.antonborri.home_widget.extra.IS_EXPEDITED"
 
-  fun getBroadcast(context: Context, uri: Uri? = null): PendingIntent {
+  fun getBroadcast(context: Context, uri: Uri? = null, expedited: Boolean = false): PendingIntent {
     val intent = Intent(context, HomeWidgetBackgroundReceiver::class.java)
     intent.data = uri
     intent.action = HOME_WIDGET_BACKGROUND_ACTION
+    intent.putExtra(EXTRA_IS_EXPEDITED, expedited)
 
     var flags = PendingIntent.FLAG_UPDATE_CURRENT
     if (Build.VERSION.SDK_INT >= 23) {


### PR DESCRIPTION
# Description

Fixes a serialization bug in `HomeWidgetPlugin.swift` where arrays of `Codable` objects (e.g., `[EntryTypeEntity]`) were not being properly encoded when extracting widget configuration via `getInstalledWidgets()`.

## Problem

When a widget configuration contains an array parameter (like `entryTypes: [EntryTypeEntity]`), the existing code would match the generic `case let arrayValue as [Any]:` case before reaching the `Codable` case. This caused raw Swift objects to be passed through the Flutter method channel, resulting in a `"Unsupported value for standard codec"` crash.

## Solution

Reordered the type checking in `getInstalledWidgets()` to handle arrays of `Codable` objects **before** the generic array case. The fix:

1. Attempts to encode each array element as `Codable`
2. Converts each element to a JSON dictionary
3. Returns the array of dictionaries if all elements encode successfully
4. Falls back to string conversion if encoding fails

This allows arrays of `AppEntity` types (which conform to `Codable`) to be properly serialized and accessible in Flutter.

## Example

**Before:** Crash when accessing `widget.configuration['entryTypes']`

**After:** Returns properly serialized array:
```dart
[
  {id: "task", displayString: "Task"},
  {id: "event", displayString: "Event"},
  {id: "note", displayString: "Note"}
]
```

## Checklist

- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation and added code (documentation) comments where necessary.
- [ ] I have updated/added relevant examples in `example` or documentation.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

## Related Issues

Fixes #376