### PR TITLE
feat: Add UIScene life cycle support

### DIFF
--- a/packages/home_widget/ios/home_widget/Sources/home_widget/HomeWidgetPlugin+SceneDelegate.swift
+++ b/packages/home_widget/ios/home_widget/Sources/home_widget/HomeWidgetPlugin+SceneDelegate.swift
@@ -1,0 +1,34 @@
+import Flutter
+import UIKit
+
+@available(iOS 13.0, *)
+extension HomeWidgetPlugin: FlutterSceneLifeCycleDelegate {
+
+  public func scene(
+    _ scene: UIScene,
+    willConnectTo session: UISceneSession,
+    options connectionOptions: UIScene.ConnectionOptions?
+  ) -> Bool {
+    guard let urlContexts = connectionOptions?.urlContexts else { return false }
+    for context in urlContexts {
+      let url = context.url
+      if isWidgetUrl(url: url) {
+        initialUrl = url
+        latestUrl = url
+        break
+      }
+    }
+    return false
+  }
+
+  public func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) -> Bool {
+    for context in URLContexts {
+      let url = context.url
+      if isWidgetUrl(url: url) {
+        latestUrl = url
+        return true
+      }
+    }
+    return false
+  }
+}

--- a/packages/home_widget/ios/home_widget/Sources/home_widget/HomeWidgetPlugin.swift
+++ b/packages/home_widget/ios/home_widget/Sources/home_widget/HomeWidgetPlugin.swift
@@ -18,8 +18,8 @@ public class HomeWidgetPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
 
   private static var groupId: String?
 
-  private var initialUrl: URL?
-  private var latestUrl: URL? {
+  var initialUrl: URL?
+  var latestUrl: URL? {
     didSet {
       if latestUrl != nil {
         eventSink?.self(latestUrl?.absoluteString)
@@ -48,13 +48,18 @@ public class HomeWidgetPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
       name: "home_widget/updates", binaryMessenger: registrar.messenger())
     eventChannel.setStreamHandler(instance)
 
-    guard isRunningInAppExtension() == false else {
-      return
-    }
+    if isRunningInAppExtension() { return }
 
     let selector = NSSelectorFromString("addApplicationDelegate:")
     if registrar.responds(to: selector) {
       registrar.perform(selector, with: instance)
+    }
+
+    if #available(iOS 13.0, *) {
+      let sceneSelector = NSSelectorFromString("addSceneDelegate:")
+      if registrar.responds(to: sceneSelector) {
+        registrar.perform(sceneSelector, with: instance)
+      }
     }
   }
 
@@ -371,8 +376,7 @@ public class HomeWidgetPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
   }
 
   public func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink)
-    -> FlutterError?
-  {
+    -> FlutterError? {
     eventSink = events
     return nil
   }
@@ -387,8 +391,8 @@ public class HomeWidgetPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
     didFinishLaunchingWithOptions launchOptions: [AnyHashable: Any] = [:]
   ) -> Bool {
     let launchUrl = (launchOptions[UIApplication.LaunchOptionsKey.url] as? NSURL)?.absoluteURL
-    if launchUrl != nil && isWidgetUrl(url: launchUrl!) {
-      initialUrl = launchUrl?.absoluteURL
+    if let launchUrl = launchUrl, isWidgetUrl(url: launchUrl) {
+      initialUrl = launchUrl.absoluteURL
       latestUrl = initialUrl
     }
     return true
@@ -405,14 +409,13 @@ public class HomeWidgetPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
     return false
   }
 
-  private func isWidgetUrl(url: URL) -> Bool {
+  func isWidgetUrl(url: URL) -> Bool {
     let components = URLComponents.init(url: url, resolvingAgainstBaseURL: false)
     return components?.queryItems?.contains(where: { (item) in item.name == "homeWidget" }) ?? false
   }
 }
 
 protocol _AnyIntentParameter {
-
   var anyWrappedValue: Any { get }
 }
 


### PR DESCRIPTION
`feat: add UIScene support for widget launch URLs on iOS`

# Description
Adds iOS 13+ UIScene lifecycle support so that widget launch URLs are handled when the app uses a scene-based lifecycle (e.g. default Flutter iOS template with `SceneDelegate`).

**Existing behavior:** Widget taps were delivered only via `UIApplicationDelegate` (`application(_:didFinishLaunchingWithOptions:)` and `application(_:open:options:)`). Apps that rely on `UISceneDelegate` for URL handling did not receive these URLs.

**Changes:**
- **HomeWidgetPlugin+SceneDelegate.swift:** Implement `FlutterSceneLifeCycleDelegate` with `scene(_:willConnectToSession:options:)` (initial launch URL from `connectionOptions.urlContexts`) and `scene(_:openURLContexts:)` (URL when app is already running). This mirrors the existing AppDelegate URL handling so `initiallyLaunchedFromHomeWidget` and the updates stream work for scene-based apps.
- **HomeWidgetPlugin.swift:** Register the plugin as a scene delegate via `addSceneDelegate:` on the registrar (using the same runtime `responds(to:)` / `perform` pattern as `addApplicationDelegate:` for backward compatibility). Only registers on iOS 13+ and when the registrar supports it. `isWidgetUrl(url:)` is made internal so the scene delegate extension can reuse it.

No Dart API changes. AppDelegate-based apps continue to work unchanged.

## Checklist

- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation and added code (documentation) comments where necessary.
- [ ] I have updated/added relevant examples in `example` or documentation.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
#399 
