### PR TITLE
feat: Add direct background execution mode bypassing WorkManager

### DIFF
--- a/packages/home_widget/android/build.gradle
+++ b/packages/home_widget/android/build.gradle
@@ -41,17 +41,17 @@ android {
         disable 'InvalidPackage'
     }
     compileOptions {
-        targetCompatibility JavaVersion.VERSION_1_8
-        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 }
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation "androidx.glance:glance-appwidget:1.+"
-    implementation "androidx.work:work-runtime-ktx:2.+"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.+"
+    implementation "androidx.glance:glance-appwidget:1.1.1"
+    implementation "androidx.work:work-runtime-ktx:2.10.2"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2"
 }

--- a/packages/home_widget/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetBackgroundReceiver.kt
+++ b/packages/home_widget/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetBackgroundReceiver.kt
@@ -10,6 +10,14 @@ class HomeWidgetBackgroundReceiver : BroadcastReceiver() {
     val flutterLoader = FlutterInjector.instance().flutterLoader()
     flutterLoader.startInitialization(context)
     flutterLoader.ensureInitializationComplete(context, null)
-    HomeWidgetBackgroundWorker.enqueueWork(context, intent)
+    if (intent.getBooleanExtra(EXTRA_DIRECT, false)) {
+      HomeWidgetBackgroundRunner.execute(context, intent, goAsync())
+    } else {
+      HomeWidgetBackgroundWorker.enqueueWork(context, intent)
+    }
+  }
+
+  companion object {
+    const val EXTRA_DIRECT = "es.antonborri.home_widget.extra.DIRECT"
   }
 }

--- a/packages/home_widget/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetBackgroundRunner.kt
+++ b/packages/home_widget/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetBackgroundRunner.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Handler
 import android.os.Looper
+import android.util.Log
 import io.flutter.FlutterInjector
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.embedding.engine.dart.DartExecutor
@@ -16,39 +17,42 @@ import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
 object HomeWidgetBackgroundRunner : MethodChannel.MethodCallHandler {
+  private const val TAG = "HomeWidgetRunner"
   private const val CHANNEL_NAME = "home_widget/background"
 
   @Volatile private var engine: FlutterEngine? = null
-  private val queue = ArrayDeque<List<Any>>()
+  @Volatile private var channel: MethodChannel? = null
+  private val queue = ArrayDeque<PendingWork>()
   private val serviceStarted = AtomicBoolean(false)
   private val mainHandler = Handler(Looper.getMainLooper())
-  private var channel: MethodChannel? = null
+  private val initMutex = Mutex()
+
+  private data class PendingWork(
+      val args: List<Any>,
+      val pendingResult: BroadcastReceiver.PendingResult,
+  )
 
   fun execute(context: Context, intent: Intent, pendingResult: BroadcastReceiver.PendingResult) {
     CoroutineScope(Dispatchers.Default).launch {
       try {
-        if (engine == null) {
-          initializeFlutterEngine(context)
-        }
-
-        engine?.let {
-          channel = MethodChannel(it.dartExecutor.binaryMessenger, CHANNEL_NAME)
-          channel?.setMethodCallHandler(this@HomeWidgetBackgroundRunner)
-        }
+        ensureEngineInitialized(context)
 
         val data = intent.data?.toString() ?: ""
         val args = listOf(HomeWidgetPlugin.getHandle(context), data)
         synchronized(serviceStarted) {
           if (!serviceStarted.get()) {
-            queue.add(args)
+            queue.add(PendingWork(args, pendingResult))
           } else {
-            mainHandler.post { channel?.invokeMethod("", args) }
+            dispatchToChannel(args, pendingResult)
           }
         }
-      } finally {
+      } catch (e: Throwable) {
+        Log.e(TAG, "Error executing background callback", e)
         pendingResult.finish()
       }
     }
@@ -68,10 +72,39 @@ object HomeWidgetBackgroundRunner : MethodChannel.MethodCallHandler {
   private fun handleBackgroundInitialized() {
     synchronized(serviceStarted) {
       while (queue.isNotEmpty()) {
-        val args = queue.remove()
-        mainHandler.post { channel?.invokeMethod("", args) }
+        val work = queue.remove()
+        dispatchToChannel(work.args, work.pendingResult)
       }
       serviceStarted.set(true)
+    }
+  }
+
+  private fun dispatchToChannel(
+      args: List<Any>,
+      pendingResult: BroadcastReceiver.PendingResult,
+  ) {
+    mainHandler.post {
+      val ch = channel
+      if (ch == null) {
+        pendingResult.finish()
+        return@post
+      }
+      // Empty method name is the expected protocol for the "home_widget/background"
+      // channel — the Dart side treats every invokeMethod call as a background
+      // callback trigger regardless of method name.
+      ch.invokeMethod("", args, object : MethodChannel.Result {
+        override fun success(result: Any?) { pendingResult.finish() }
+        override fun error(code: String, message: String?, details: Any?) { pendingResult.finish() }
+        override fun notImplemented() { pendingResult.finish() }
+      })
+    }
+  }
+
+  private suspend fun ensureEngineInitialized(context: Context) {
+    if (engine != null) return
+    initMutex.withLock {
+      if (engine != null) return
+      initializeFlutterEngine(context)
     }
   }
 
@@ -88,14 +121,29 @@ object HomeWidgetBackgroundRunner : MethodChannel.MethodCallHandler {
             ?: throw IllegalStateException("Failed to lookup callback information")
 
     withContext(Dispatchers.Main) {
-      engine = FlutterEngine(context)
-      val callback =
-          DartExecutor.DartCallback(
-              context.assets,
-              FlutterInjector.instance().flutterLoader().findAppBundlePath(),
-              callbackInfo,
-          )
-      engine?.dartExecutor?.executeDartCallback(callback)
+      try {
+        engine = FlutterEngine(context)
+        val callback =
+            DartExecutor.DartCallback(
+                context.assets,
+                FlutterInjector.instance().flutterLoader().findAppBundlePath(),
+                callbackInfo,
+            )
+        engine?.dartExecutor?.executeDartCallback(callback)
+        engine?.let {
+          channel = MethodChannel(it.dartExecutor.binaryMessenger, CHANNEL_NAME)
+          channel?.setMethodCallHandler(this@HomeWidgetBackgroundRunner)
+        }
+      } catch (e: Throwable) {
+        Log.e(
+            TAG,
+            "Failed to initialize FlutterEngine (callbackHandle=$callbackHandle, callbackInfo=$callbackInfo)",
+            e,
+        )
+        engine = null
+        channel = null
+        throw e
+      }
     }
   }
 }

--- a/packages/home_widget/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetBackgroundRunner.kt
+++ b/packages/home_widget/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetBackgroundRunner.kt
@@ -1,0 +1,101 @@
+package es.antonborri.home_widget
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Handler
+import android.os.Looper
+import io.flutter.FlutterInjector
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.embedding.engine.dart.DartExecutor
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.view.FlutterCallbackInformation
+import java.util.ArrayDeque
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+object HomeWidgetBackgroundRunner : MethodChannel.MethodCallHandler {
+  private const val CHANNEL_NAME = "home_widget/background"
+
+  @Volatile private var engine: FlutterEngine? = null
+  private val queue = ArrayDeque<List<Any>>()
+  private val serviceStarted = AtomicBoolean(false)
+  private val mainHandler = Handler(Looper.getMainLooper())
+  private var channel: MethodChannel? = null
+
+  fun execute(context: Context, intent: Intent, pendingResult: BroadcastReceiver.PendingResult) {
+    CoroutineScope(Dispatchers.Default).launch {
+      try {
+        if (engine == null) {
+          initializeFlutterEngine(context)
+        }
+
+        engine?.let {
+          channel = MethodChannel(it.dartExecutor.binaryMessenger, CHANNEL_NAME)
+          channel?.setMethodCallHandler(this@HomeWidgetBackgroundRunner)
+        }
+
+        val data = intent.data?.toString() ?: ""
+        val args = listOf(HomeWidgetPlugin.getHandle(context), data)
+        synchronized(serviceStarted) {
+          if (!serviceStarted.get()) {
+            queue.add(args)
+          } else {
+            mainHandler.post { channel?.invokeMethod("", args) }
+          }
+        }
+      } finally {
+        pendingResult.finish()
+      }
+    }
+  }
+
+  override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+    when (call.method) {
+      "HomeWidget.backgroundInitialized" -> {
+        handleBackgroundInitialized()
+        result.success(null)
+      }
+
+      else -> result.notImplemented()
+    }
+  }
+
+  private fun handleBackgroundInitialized() {
+    synchronized(serviceStarted) {
+      while (queue.isNotEmpty()) {
+        val args = queue.remove()
+        mainHandler.post { channel?.invokeMethod("", args) }
+      }
+      serviceStarted.set(true)
+    }
+  }
+
+  private suspend fun initializeFlutterEngine(context: Context) {
+    val callbackHandle = HomeWidgetPlugin.getDispatcherHandle(context)
+    if (callbackHandle == 0L) {
+      throw IllegalStateException(
+          "No callbackHandle saved. Did you call HomeWidget.registerBackgroundCallback?"
+      )
+    }
+
+    val callbackInfo =
+        FlutterCallbackInformation.lookupCallbackInformation(callbackHandle)
+            ?: throw IllegalStateException("Failed to lookup callback information")
+
+    withContext(Dispatchers.Main) {
+      engine = FlutterEngine(context)
+      val callback =
+          DartExecutor.DartCallback(
+              context.assets,
+              FlutterInjector.instance().flutterLoader().findAppBundlePath(),
+              callbackInfo,
+          )
+      engine?.dartExecutor?.executeDartCallback(callback)
+    }
+  }
+}

--- a/packages/home_widget/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetIntent.kt
+++ b/packages/home_widget/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetIntent.kt
@@ -54,10 +54,11 @@ inline fun <reified T : Activity> actionStartActivity(context: Context, uri: Uri
 object HomeWidgetBackgroundIntent {
   private const val HOME_WIDGET_BACKGROUND_ACTION = "es.antonborri.home_widget.action.BACKGROUND"
 
-  fun getBroadcast(context: Context, uri: Uri? = null): PendingIntent {
+  fun getBroadcast(context: Context, uri: Uri? = null, direct: Boolean = false): PendingIntent {
     val intent = Intent(context, HomeWidgetBackgroundReceiver::class.java)
     intent.data = uri
     intent.action = HOME_WIDGET_BACKGROUND_ACTION
+    intent.putExtra(HomeWidgetBackgroundReceiver.EXTRA_DIRECT, direct)
 
     var flags = PendingIntent.FLAG_UPDATE_CURRENT
     if (Build.VERSION.SDK_INT >= 23) {


### PR DESCRIPTION
## Description

Adds a new `direct` execution mode for Android background callbacks that runs Dart code directly in the `BroadcastReceiver` using `goAsync()`, bypassing WorkManager entirely.

On some devices, WorkManager tasks are delayed between being queued and executed, and on others, they don’t run at all. I’m not sure whether this is an existing issue or something that started happening more recently. #361 

`HomeWidgetBackgroundIntent.getBroadcast(context, uri, direct = true)`

  ## Checklist

  - [ ] I have updated/added tests for ALL new/updated/fixed functionality.
  - [ ] I have updated/added relevant documentation and added code (documentation) comments where necessary.
  - [ ] I have updated/added relevant examples in `example` or documentation.

  ## Breaking Change?

  - [ ] Yes, this PR is a breaking change.
  - [x] No, this PR is not a breaking change.