### PR TITLE
fix(ios): Avoid duplicate app-delegate on background engine

### DIFF
--- a/packages/home_widget/ios/home_widget/Sources/home_widget/HomeWidgetBackgroundWorker.swift
+++ b/packages/home_widget/ios/home_widget/Sources/home_widget/HomeWidgetBackgroundWorker.swift
@@ -20,6 +20,7 @@ public struct HomeWidgetBackgroundWorker {
 
   static var isSetupCompleted: Bool = false
   static var continuations: [CheckedContinuation<Void, Never>] = []
+  static var currentDispatcher: Int64?
 
   private static var registerPlugins: FlutterPluginRegistrantCallback?
 
@@ -44,7 +45,39 @@ public struct HomeWidgetBackgroundWorker {
     await sendEvent(url: url, appGroup: appGroup)
   }
 
+  /// Spins up the headless background `FlutterEngine` that runs the Dart
+  /// interactivity callback and wires the `home_widget/background` method
+  /// channel used to dispatch widget-triggered events into Dart. If a custom
+  /// `FlutterPluginRegistrantCallback` has been supplied via
+  /// `setPluginRegistrantCallback` it is invoked to register any additional
+  /// plugins needed by the background isolate; otherwise only the
+  /// `home_widget` channels are registered on the background engine to avoid
+  /// perturbing the host app's plugin delegate chain. Re-entrant: if the same
+  /// dispatcher is re-registered after a completed setup the call is a no-op;
+  /// if the dispatcher changes, or the previous setup never finished handshake
+  /// with Dart (`HomeWidget.backgroundInitialized` was never received), the
+  /// previous engine is torn down and a fresh one is spun up so the caller
+  /// always has a usable background isolate.
   static func setupEngine(dispatcher: Int64) {
+    if engine != nil && currentDispatcher == dispatcher && isSetupCompleted {
+      return
+    }
+
+    if let previous = engine {
+      channel?.setMethodCallHandler(nil)
+      previous.destroyContext()
+      engine = nil
+      channel = nil
+      isSetupCompleted = false
+      // Unblock any pending `run` waiters — the engine they were waiting on is
+      // gone and a new one is about to be created that will emit its own
+      // `backgroundInitialized`. Leaving them suspended would deadlock.
+      while !continuations.isEmpty {
+        continuations.removeFirst().resume()
+      }
+    }
+    currentDispatcher = dispatcher
+
     engine = FlutterEngine(
       name: "home_widget_background", project: nil, allowHeadlessExecution: true)
 
@@ -53,16 +86,18 @@ public struct HomeWidgetBackgroundWorker {
       codec: FlutterStandardMethodCodec.sharedInstance()
     )
     let flutterCallbackInfo = FlutterCallbackCache.lookupCallbackInformation(dispatcher)
-    let callbackName = flutterCallbackInfo?.callbackName
-    let callbackLibrary = flutterCallbackInfo?.callbackLibraryPath
 
-    let started = engine?.run(
+    engine?.run(
       withEntrypoint: flutterCallbackInfo?.callbackName,
       libraryURI: flutterCallbackInfo?.callbackLibraryPath)
     if registerPlugins != nil {
       registerPlugins?(engine!)
     } else {
-      HomeWidgetPlugin.register(with: engine!.registrar(forPlugin: "home_widget")!)
+      // Register only the channels on the background engine — do NOT add a
+      // second HomeWidgetPlugin to the main app's UIApplication delegate chain,
+      // which breaks URL/life-cycle callbacks in other plugins (issue #408).
+      HomeWidgetPlugin.registerChannels(
+        with: engine!.registrar(forPlugin: "home_widget")!)
     }
 
     channel?.setMethodCallHandler(handle)

--- a/packages/home_widget/ios/home_widget/Sources/home_widget/HomeWidgetPlugin.swift
+++ b/packages/home_widget/ios/home_widget/Sources/home_widget/HomeWidgetPlugin.swift
@@ -38,15 +38,13 @@ public class HomeWidgetPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
     return bundlePathExtension == "appex"
   }
 
+  /// Flutter plugin entry point. Registers the `home_widget` method channel
+  /// and `home_widget/updates` event channel against `registrar`, and — when
+  /// running inside the host app (not an app extension) — inserts the plugin
+  /// into the `UIApplication` delegate chain so it can observe launch URLs
+  /// and incoming `open:` calls originating from home-screen widgets.
   public static func register(with registrar: FlutterPluginRegistrar) {
-    let instance = HomeWidgetPlugin()
-
-    let channel = FlutterMethodChannel(name: "home_widget", binaryMessenger: registrar.messenger())
-    registrar.addMethodCallDelegate(instance, channel: channel)
-
-    let eventChannel = FlutterEventChannel(
-      name: "home_widget/updates", binaryMessenger: registrar.messenger())
-    eventChannel.setStreamHandler(instance)
+    let instance = registerChannels(with: registrar)
 
     guard isRunningInAppExtension() == false else {
       return
@@ -56,6 +54,28 @@ public class HomeWidgetPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
     if registrar.responds(to: selector) {
       registrar.perform(selector, with: instance)
     }
+  }
+
+  /// Registers only the method/event channels against the given registrar,
+  /// without inserting the plugin into the host app's UIApplication delegate
+  /// chain. Used for the secondary `FlutterEngine` created for interactivity
+  /// callbacks: the background isolate still needs the `home_widget` channel,
+  /// but adding another `HomeWidgetPlugin` to the main app's delegate chain
+  /// disturbs URL/life-cycle propagation for other plugins (see issue #408).
+  @discardableResult
+  public static func registerChannels(with registrar: FlutterPluginRegistrar)
+    -> HomeWidgetPlugin
+  {
+    let instance = HomeWidgetPlugin()
+
+    let channel = FlutterMethodChannel(name: "home_widget", binaryMessenger: registrar.messenger())
+    registrar.addMethodCallDelegate(instance, channel: channel)
+
+    let eventChannel = FlutterEventChannel(
+      name: "home_widget/updates", binaryMessenger: registrar.messenger())
+    eventChannel.setStreamHandler(instance)
+
+    return instance
   }
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {


### PR DESCRIPTION
HomeWidgetBackgroundWorker.setupEngine used HomeWidgetPlugin.register on the secondary FlutterEngine, which also calls addApplicationDelegate: and inserts another HomeWidgetPlugin into the host app's UIApplication delegate chain. That extra delegate disturbs URL/life-cycle propagation for other plugins (e.g. appsflyer_sdk deep-link/attribution callbacks).

Split register into a channel-only registerChannels path and use it for the background engine so the background isolate still has the home_widget channel without polluting the main app's delegate chain. Also guard setupEngine so repeated registerBackgroundCallback calls do not leak engines.

Closes #408

<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
Replace this text.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added code (documentation) comments where necessary.
- [x] I have updated/added relevant examples in `example` or documentation.


## Breaking Change?
<!--
Would your PR require home_widget users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version below:
-->


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/abausg/home_widget/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->