### PR TITLE
fix: Pin android dependency versions to prevent pre-release pickup

### DIFF
--- a/packages/home_widget/android/build.gradle
+++ b/packages/home_widget/android/build.gradle
@@ -51,7 +51,7 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation "androidx.glance:glance-appwidget:1.+"
-    implementation "androidx.work:work-runtime-ktx:2.+"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.+"
+    implementation "androidx.glance:glance-appwidget:1.1.1"
+    implementation "androidx.work:work-runtime-ktx:2.11.2"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2"
 }


### PR DESCRIPTION
# Description
Replaces three dynamic version selectors with concrete latest-stable versions in `build.gradle`

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [X] I have updated/added tests for ALL new/updated/fixed functionality.
- [X] I have updated/added relevant documentation and added code (documentation) comments where necessary.
- [X] I have updated/added relevant examples in `example` or documentation.


## Breaking Change?
- [ ] Yes, this PR is a breaking change.
- [X] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version below:
-->


## Related Issues
Closes #417