### PR TITLE
fix: Add FlutterFramework to iOS SPM package

### DIFF
--- a/packages/home_widget/ios/home_widget/Package.swift
+++ b/packages/home_widget/ios/home_widget/Package.swift
@@ -11,11 +11,15 @@ let package = Package(
   products: [
     .library(name: "home-widget", targets: ["home_widget"])
   ],
-  dependencies: [],
+  dependencies: [
+    .package(name: "FlutterFramework", path: "../FlutterFramework")
+  ],
   targets: [
     .target(
       name: "home_widget",
-      dependencies: []
+      dependencies: [
+        .product(name: "FlutterFramework", package: "FlutterFramework")
+      ]
     )
   ]
 )


### PR DESCRIPTION
## Summary
- add the local `FlutterFramework` package dependency to the iOS Swift Package manifest
- link the `home_widget` target against the FlutterFramework product so Swift sources can resolve `import Flutter` when Flutter builds plugins through SPM

## Validation
- `swift package dump-package --package-path packages/home_widget/ios/home_widget` with a temporary local `../FlutterFramework` link
- `git diff --cached --check`
