### PR TITLE
fix: Support Android Gradle Plugin 9.x

### DIFF
--- a/packages/home_widget/android/build.gradle
+++ b/packages/home_widget/android/build.gradle
@@ -21,8 +21,12 @@ rootProject.allprojects {
     }
 }
 
+def isAgp9OrAbove = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger() >= 9
+
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+if (!isAgp9OrAbove) {
+    apply plugin: 'kotlin-android'
+}
 
 android {
     // Conditional for compatibility with AGP <4.2.
@@ -44,8 +48,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
         sourceCompatibility JavaVersion.VERSION_1_8
     }
-    kotlinOptions {
-        jvmTarget = "1.8"
+    if (!isAgp9OrAbove) {
+        kotlinOptions {
+            jvmTarget = "1.8"
+        }
     }
 }
 


### PR DESCRIPTION
# Description

Starting with Android Gradle Plugin 9.0, Kotlin support is embedded in
AGP itself and applying the standalone `kotlin-android` plugin causes a
build failure.

This PR detects the AGP version and skips both the plugin application
and the `kotlinOptions` block when running on AGP 9 or above, keeping
the existing behavior unchanged for AGP 8.x and below.

Same approach used by [file_picker](https://github.com/miguelpruivo/flutter_file_picker)
since version 10.x.

## Checklist

- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation and added code (documentation) comments where necessary.
- [ ] I have updated/added relevant examples in `example` or documentation.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.