### PR TITLE
fix: Restore docs.page sidebar navigation and package tabs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1,18 +1,22 @@
 {
+  "$schema": "https://docs.page/schema.json",
   "name": "home_widget",
-  "theme": "#567acb",
+  "description": "Documentation for the home_widget Flutter package and related tools.",
+  "theme": {
+    "primary": "#567acb"
+  },
   "content": {
     "headerDepth": 4
   },
   "social": {
     "x": "@abausg",
-    "github": "abausg",
+    "github": "ABausG/home_widget",
     "linkedin": "/in/abausg"
   },
   "tabs": [
     {
-      "id": "documentation",
-      "title": "Documentation",
+      "id": "home_widget",
+      "title": "home_widget",
       "href": "/"
     },
     {
@@ -28,21 +32,16 @@
   ],
   "sidebar": [
     {
-      "tab": "documentation",
+      "tab": "home_widget",
+      "group": "Getting Started",
       "pages": [
-        { "title": "Overview", "href": "/" }
-      ]
-    },
-    {
-      "tab": "documentation",
-      "group": "Usage",
-      "pages": [
+        { "title": "Overview", "href": "/index" },
         { "title": "Sync Data", "href": "/usage/sync-data" },
         { "title": "Update Widget", "href": "/usage/update-widget" }
       ]
     },
     {
-      "tab": "documentation",
+      "tab": "home_widget",
       "group": "Platform Setup",
       "pages": [
         { "title": "iOS", "href": "/setup/ios" },
@@ -50,7 +49,7 @@
       ]
     },
     {
-      "tab": "documentation",
+      "tab": "home_widget",
       "group": "Features",
       "pages": [
         { "title": "Render Flutter Widgets", "href": "/features/render-flutter-widgets" },
@@ -65,7 +64,7 @@
       ]
     },
     {
-      "tab": "documentation",
+      "tab": "home_widget",
       "group": "Migrations",
       "pages": [
         { "title": "0.9.0", "href": "/migrations/0.9.0" },
@@ -73,7 +72,7 @@
       ]
     },
     {
-      "tab": "documentation",
+      "tab": "home_widget",
       "group": "Android XML",
       "pages": [
         { "title": "Overview", "href": "/android-xml/overview" },
@@ -85,6 +84,7 @@
     },
     {
       "tab": "generator",
+      "group": "Getting Started",
       "pages": [
         { "title": "Overview", "href": "/generator" },
         { "title": "Getting Started", "href": "/generator/getting-started" },
@@ -124,15 +124,14 @@
     {
       "tab": "cli",
       "pages": [
-        { "title": "Overview", "href": "/cli" }
-      ]
-    },
-    {
-      "tab": "cli",
-      "group": "Commands",
-      "pages": [
-        { "title": "create", "href": "/cli/create" },
-        { "title": "generate", "href": "/cli/generate" }
+        { "title": "Overview", "href": "/cli" },
+        {
+          "group": "Commands",
+          "pages": [
+            { "title": "create", "href": "/cli/create" },
+            { "title": "generate", "href": "/cli/generate" }
+          ]
+        }
       ]
     }
   ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the missing left sidebar and top package tabs on [docs.page/abausg/home_widget](https://docs.page/abausg/home_widget).

The `docs.json` configuration introduced in #428 had the correct tab/sidebar structure, but `theme` was set as a plain string (`"#567acb"`). docs.page validates config against its JSON schema, which requires `theme` to be an object (e.g. `{ "primary": "#567acb" }`). When validation fails, `tabs` and `sidebar` are dropped entirely — which is why the site rendered content but no navigation.

## Changes

- Fix `theme` to use the schema-compliant object format
- Add `$schema` for IDE validation (same as widgetbook)
- Rename the main tab from "Documentation" to **home_widget** (alongside **Generator** and **CLI**)
- Reorganize sidebar groups to follow the widgetbook pattern:
  - Grouped sections per tab with sensible headings
  - Nested CLI commands under a single tab entry
  - Overview linked via `/index` (docs.page convention)
- Set `social.github` to the full repo path for the GitHub header card

## Verification

Validated `docs.json` against `https://docs.page/schema.json` — passes after the theme fix.

Once merged, docs.page should show:
- Top tabs: **home_widget** | **Generator** | **CLI**
- Left sidebar with grouped pages per tab (Usage, Platform Setup, Features, etc.)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-24b2d44c-6cd4-45a7-863c-59c4278dd1fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24b2d44c-6cd4-45a7-863c-59c4278dd1fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

