### PR TITLE
docs: add AGENTS.md for Cursor Cloud development setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### What this repo is
+
+Flutter/Dart monorepo for the **home_widget** plugin ecosystem (plugin, generator, CLI, and example apps). There is no backend or database — development is Flutter + Melos + platform SDKs.
+
+### Toolchain (pre-installed on the VM snapshot)
+
+- **Flutter**: `~/flutter` (stable channel). Ensure `$HOME/flutter/bin` is on `PATH`.
+- **Melos**: activated globally via `dart pub global activate melos`. Ensure `$HOME/.pub-cache/bin` is on `PATH` so `melos run …` scripts work (they invoke `melos` internally).
+- **Android SDK**: `$HOME/Android/Sdk` with platforms 33/35/36, build-tools, emulator, and an x86_64 system image. Set `ANDROID_HOME` and point Flutter at it with `flutter config --android-sdk "$ANDROID_HOME"`.
+- **JDK 21**: OpenJDK 21 (`JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64`).
+
+### Bootstrap (after `git pull`)
+
+From repo root:
+
+```bash
+dart pub get
+melos bootstrap
+```
+
+The VM update script runs the dependency refresh steps above automatically.
+
+### Common commands
+
+| Task | Command |
+|------|---------|
+| Analyze all packages | `melos analyze` |
+| Unit tests (all packages) | `melos run test` |
+| Flutter tests (one package) | `cd packages/home_widget && flutter test` |
+| Dart tests (CLI/generator) | `cd packages/home_widget_cli && dart test` |
+| Build Android example APK | `cd examples/generator_basics && flutter build apk --debug` |
+| Generate native widget code | `cd examples/generator_basics && dart run home_widget_cli:home_widget generate` |
+
+Melos script definitions live in root `pubspec.yaml` under the `melos:` key.
+
+### Non-obvious gotchas
+
+- **CLI executable name**: The CLI package is `home_widget_cli`, but its executable is `home_widget`. In this workspace, `dart run home_widget` resolves to the *plugin* package and fails. Use `dart run home_widget_cli:home_widget <command>` from example apps.
+- **Android emulator**: `/dev/kvm` is not available in this cloud VM, so `flutter run` on an emulator will not work. Validate Android with `flutter build apk` or CI-style Gradle builds instead.
+- **iOS builds/tests**: Require macOS + Xcode; not available on Linux cloud agents.
+- **Full `melos format:all`**: Needs `ktfmt` and `swift-format` (installed via Homebrew on macOS in CI). `melos analyze` and `melos run test` are sufficient for Linux validation.
+- **First Android build**: Gradle may download NDK/CMake on first run; subsequent builds are much faster.
+
+### Example apps
+
+Runnable demos under `examples/` (`generator_basics` is the smallest). Typical flow: generate native code with the CLI, then build or run on a device/emulator.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud–specific instructions for developing in this Flutter/Melos monorepo.

Documented during initial cloud VM environment setup:
- Flutter SDK, Melos, and Android SDK locations
- Bootstrap and common commands (`melos analyze`, `melos run test`, CLI generate, APK build)
- Gotchas (CLI executable naming, no KVM/emulator on Linux cloud, iOS requires macOS)

## VM update script

```
dart pub global activate melos
dart pub get
melos bootstrap
```

## Test plan

- [x] `dart pub get` + `melos bootstrap` at repo root
- [x] `melos analyze` — all packages clean (1 info in home_widget_cli)
- [x] `melos run test` — all unit tests passed
- [x] `dart run home_widget_cli:home_widget generate` in `examples/generator_basics`
- [x] `flutter build apk --debug` in `examples/generator_basics`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-526966c9-4a8a-491d-86ad-ab9148847197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-526966c9-4a8a-491d-86ad-ab9148847197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

