### PR TITLE
feat: Migrate examples to built-in Kotlin and iOS SPM path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,17 @@ jobs:
         run: brew install swift-format ktfmt
       - name: Analyze
         run: melos analyze
+      - name: Migration Guardrails
+        run: |
+          if rg -n "android\.builtInKotlin=false|android\.newDsl=false" examples packages/home_widget/example; then
+            echo "Legacy Android migration flags are still present."
+            exit 1
+          fi
+
+          if rg -n "pod 'home_widget'" packages/home_widget/example/ios/Podfile; then
+            echo "The package example should rely on Swift Package Manager instead of a direct home_widget pod in the widget extension."
+            exit 1
+          fi
       - name: Format
         run: melos format:all
       - name: Publishability

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,17 +33,6 @@ jobs:
         run: brew install swift-format ktfmt
       - name: Analyze
         run: melos analyze
-      - name: Migration Guardrails
-        run: |
-          if rg -n "android\.builtInKotlin=false|android\.newDsl=false" examples packages/home_widget/example; then
-            echo "Legacy Android migration flags are still present."
-            exit 1
-          fi
-
-          if rg -n "pod 'home_widget'" packages/home_widget/example/ios/Podfile; then
-            echo "The package example should rely on Swift Package Manager instead of a direct home_widget pod in the widget extension."
-            exit 1
-          fi
       - name: Format
         run: melos format:all
       - name: Publishability

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## Unreleased
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - [`home_widget` - `vNEXT`](#home_widget---vnext)
+
+Packages with other changes:
+
+ - There are no other changes in this release.
+
+---
+
+#### `home_widget` - `vNEXT`
+
+ - **BREAKING** **FEAT**: Migrate example integrations to Swift Package Manager on iOS and built-in Kotlin on Android.
+ - **BREAKING** **FEAT**: `home_widget` is now built-in-Kotlin-only on Android. The legacy `android.builtInKotlin=false` / `android.newDsl=false` compatibility path was removed.
+ - **BREAKING** **FEAT**: Consumers now need Flutter 3.44+ and the matching built-in Kotlin Android toolchain.
+ - **DOCS**: Add migration documentation for built-in Kotlin and clarify the Swift Package Manager integration path.
+
 ## 2026-06-07
 
 ### Changes

--- a/docs.json
+++ b/docs.json
@@ -68,6 +68,7 @@
       "group": "Migrations",
       "pages": [
         { "title": "0.9.0", "href": "/migrations/0.9.0" },
+        { "title": "Built-in Kotlin", "href": "/migrations/built-in-kotlin" },
         { "title": "Swift Package Manager", "href": "/migrations/swift-package-manager" }
       ]
     },

--- a/docs/features/interactive-widgets.mdx
+++ b/docs/features/interactive-widgets.mdx
@@ -31,6 +31,10 @@ Using home_widget you can register Dart Callbacks that get invoked from the Nati
 
 ## iOS Setup
 
+<Info>
+If your Flutter app uses Swift Package Manager, prefer the Swift Package Manager path below. Only keep the CocoaPods setup when your app has not migrated yet.
+</Info>
+
 ### CocoaPods
 
 If you manage your iOS dependencies with CocoaPods, adjust your Podfile to add `home_widget` as a dependency to your WidgetExtension:

--- a/docs/migrations/built-in-kotlin.mdx
+++ b/docs/migrations/built-in-kotlin.mdx
@@ -1,0 +1,51 @@
+---
+title: Built-in Kotlin
+description: Migrate Android app projects to Flutter's built-in Kotlin support for home_widget
+---
+
+# Built-in Kotlin Migration
+
+Recent Flutter and Android Gradle Plugin versions enable Kotlin support without the legacy migration flags that Flutter added during the transition.
+
+`home_widget` now uses the built-in Kotlin path on Android.
+
+That means:
+
+- `home_widget` no longer supports the legacy `android.builtInKotlin=false` and `android.newDsl=false` compatibility path.
+- Consumers should use Flutter 3.44+ and the matching modern Android toolchain.
+- Projects that still rely on the old Kotlin Gradle Plugin compatibility mode should migrate before upgrading.
+
+If your project was migrated gradually, you might still have these entries in `android/gradle.properties`:
+
+```properties
+android.builtInKotlin=false
+android.newDsl=false
+```
+
+Remove both properties so your Android project uses the current Flutter and AGP defaults.
+
+<Info>
+Flutter can add these flags back during `flutter build` or `flutter run` while your app still depends on plugins that have not fully migrated to built-in Kotlin, or while you are validating older AGP consumers. In that case, finish migrating the remaining plugins or update your Android toolchain before removing the flags again.
+</Info>
+
+## Recommended checks
+
+After removing the legacy flags, verify the following:
+
+1. Your project builds with the Flutter version required by `home_widget`.
+2. Your Android project uses a recent AGP version.
+3. Your widget app still builds successfully with `flutter build apk` or `flutter build appbundle`.
+
+## Notes for home_widget users
+
+- The `home_widget` Android plugin now expects built-in Kotlin support.
+- The migration is usually limited to removing the old Flutter migrator flags from `gradle.properties`.
+- If you keep custom Android build logic, validate that logic on a modern AGP/Kotlin toolchain after the flag removal.
+
+## Upgrade Checklist
+
+Before upgrading, verify the following in your app:
+
+1. `android/gradle.properties` no longer contains the legacy Flutter migrator flags.
+2. Your app and widget modules build successfully with built-in Kotlin enabled.
+3. Your Flutter and Android toolchain already match the baseline required by the package.

--- a/docs/setup/android.mdx
+++ b/docs/setup/android.mdx
@@ -11,6 +11,10 @@ previous: /setup/ios
 Learn how to setup home_widget on Android for your Flutter App using Jetpack Glance.
 
 <Info>
+`home_widget` now expects Flutter's built-in Kotlin path on Android. If your Android project still contains `android.builtInKotlin=false` or `android.newDsl=false` in `android/gradle.properties`, remove those legacy Flutter migrator flags first. See the [Built-in Kotlin migration guide](/migrations/built-in-kotlin).
+</Info>
+
+<Info>
 If you are looking for support for Android XML Widgets, please refer to the [Android XML](/android-xml/overview) section.
 </Info>
 

--- a/docs/setup/ios.mdx
+++ b/docs/setup/ios.mdx
@@ -10,6 +10,10 @@ next: /setup/android
 On iOS Widgets are an App Extension.
 The following steps explain how to add the correct App Extension, how to do the basic configuration to read/display data you send from your App in the Widget and how to setup GroupIds to ensure the correct communication between your App and the Widget.
 
+<Info>
+If your Flutter app uses Swift Package Manager, keep that integration enabled for `home_widget` as well. For interactive widgets, follow the [Swift Package Manager migration guide](/migrations/swift-package-manager) instead of adding a direct `pod 'home_widget'` dependency to the widget extension.
+</Info>
+
 
 ## Add a Widget to your App in Xcode
 Add a widget extension by going <kbd>File</kbd> > <kbd>New</kbd> > <kbd>Target</kbd> > <kbd>Widget Extension</kbd>

--- a/examples/configurable_widget/android/app/build.gradle.kts
+++ b/examples/configurable_widget/android/app/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
   id("com.android.application")
-  id("kotlin-android")
-  id("org.jetbrains.kotlin.plugin.compose") version "2.2.20"
+  id("org.jetbrains.kotlin.plugin.compose")
   // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
   id("dev.flutter.flutter-gradle-plugin")
 }
@@ -15,8 +14,6 @@ android {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
   }
-
-  kotlinOptions { jvmTarget = JavaVersion.VERSION_17.toString() }
 
   defaultConfig {
     // TODO: Specify your own unique Application ID
@@ -38,6 +35,12 @@ android {
     }
   }
   buildFeatures { compose = true }
+}
+
+kotlin {
+  compilerOptions {
+    jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+  }
 }
 
 flutter { source = "../.." }

--- a/examples/configurable_widget/android/settings.gradle.kts
+++ b/examples/configurable_widget/android/settings.gradle.kts
@@ -20,6 +20,7 @@ plugins {
   id("dev.flutter.flutter-plugin-loader") version "1.0.0"
   id("com.android.application") version "8.11.1" apply false
   id("org.jetbrains.kotlin.android") version "2.2.20" apply false
+  id("org.jetbrains.kotlin.plugin.compose") version "2.2.20" apply false
 }
 
 include(":app")

--- a/examples/file_and_images/android/app/build.gradle.kts
+++ b/examples/file_and_images/android/app/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
   id("com.android.application")
-  id("kotlin-android")
-  id("org.jetbrains.kotlin.plugin.compose") version "2.2.20"
+  id("org.jetbrains.kotlin.plugin.compose")
   // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
   id("dev.flutter.flutter-gradle-plugin")
 }
@@ -15,8 +14,6 @@ android {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
   }
-
-  kotlinOptions { jvmTarget = JavaVersion.VERSION_17.toString() }
 
   defaultConfig {
     // TODO: Specify your own unique Application ID
@@ -38,6 +35,12 @@ android {
     }
   }
   buildFeatures { compose = true }
+}
+
+kotlin {
+  compilerOptions {
+    jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+  }
 }
 
 flutter { source = "../.." }

--- a/examples/file_and_images/android/gradle.properties
+++ b/examples/file_and_images/android/gradle.properties
@@ -1,6 +1,2 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
-# This builtInKotlin flag was added automatically by Flutter migrator
-android.builtInKotlin=false
-# This newDsl flag was added automatically by Flutter migrator
-android.newDsl=false

--- a/examples/file_and_images/android/settings.gradle.kts
+++ b/examples/file_and_images/android/settings.gradle.kts
@@ -20,6 +20,7 @@ plugins {
   id("dev.flutter.flutter-plugin-loader") version "1.0.0"
   id("com.android.application") version "8.11.1" apply false
   id("org.jetbrains.kotlin.android") version "2.2.20" apply false
+  id("org.jetbrains.kotlin.plugin.compose") version "2.2.20" apply false
 }
 
 include(":app")

--- a/examples/generator_basics/android/app/build.gradle.kts
+++ b/examples/generator_basics/android/app/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
   id("com.android.application")
-  id("kotlin-android")
-  id("org.jetbrains.kotlin.plugin.compose") version "2.2.20"
+  id("org.jetbrains.kotlin.plugin.compose")
   // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
   id("dev.flutter.flutter-gradle-plugin")
 }
@@ -15,8 +14,6 @@ android {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
   }
-
-  kotlinOptions { jvmTarget = JavaVersion.VERSION_17.toString() }
 
   defaultConfig {
     // TODO: Specify your own unique Application ID
@@ -38,6 +35,12 @@ android {
     }
   }
   buildFeatures { compose = true }
+}
+
+kotlin {
+  compilerOptions {
+    jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+  }
 }
 
 flutter { source = "../.." }

--- a/examples/generator_basics/android/settings.gradle.kts
+++ b/examples/generator_basics/android/settings.gradle.kts
@@ -20,6 +20,7 @@ plugins {
   id("dev.flutter.flutter-plugin-loader") version "1.0.0"
   id("com.android.application") version "8.11.1" apply false
   id("org.jetbrains.kotlin.android") version "2.2.20" apply false
+  id("org.jetbrains.kotlin.plugin.compose") version "2.2.20" apply false
 }
 
 include(":app")

--- a/packages/home_widget/CHANGELOG.md
+++ b/packages/home_widget/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+ - **BREAKING** **FEAT**: Migrate example integrations to Swift Package Manager on iOS and built-in Kotlin on Android.
+ - **BREAKING** **FEAT**: `home_widget` is now built-in-Kotlin-only on Android. The legacy `android.builtInKotlin=false` / `android.newDsl=false` compatibility path was removed.
+ - **BREAKING** **FEAT**: Consumers now need Flutter 3.44+ and the matching built-in Kotlin Android toolchain.
+ - **DOCS**: Add migration documentation for built-in Kotlin and clarify the Swift Package Manager integration path.
+
 ## 0.9.3
 
  - **FEAT**: Support UIScene Lifecycle ([#423](https://github.com/abausg/home_widget/issues/423)). ([bd899596](https://github.com/abausg/home_widget/commit/bd8995964680fb5507414f54beea4f2e6514b456))

--- a/packages/home_widget/android/build.gradle
+++ b/packages/home_widget/android/build.gradle
@@ -2,7 +2,6 @@ group 'es.antonborri.home_widget'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.9.0'
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:8.1.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -21,15 +19,7 @@ rootProject.allprojects {
     }
 }
 
-def isAgp9OrAbove = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger() >= 9
-def builtInKotlinProperty = project.findProperty('android.builtInKotlin') ?: rootProject.findProperty('android.builtInKotlin')
-// AGP 9+ enables built-in Kotlin by default; Flutter sets android.builtInKotlin=false during migration.
-def useBuiltInKotlin = isAgp9OrAbove && (builtInKotlinProperty == null ? true : builtInKotlinProperty.toString().toBoolean())
-
 apply plugin: 'com.android.library'
-if (!useBuiltInKotlin) {
-    apply plugin: 'kotlin-android'
-}
 
 android {
     // Conditional for compatibility with AGP <4.2.
@@ -48,18 +38,18 @@ android {
         disable 'InvalidPackage'
     }
     compileOptions {
-        targetCompatibility JavaVersion.VERSION_1_8
-        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_17
     }
-    if (!useBuiltInKotlin) {
-        kotlinOptions {
-            jvmTarget = "1.8"
-        }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget("17")
     }
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "androidx.glance:glance-appwidget:1.1.1"
     implementation "androidx.work:work-runtime-ktx:2.11.2"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2"

--- a/packages/home_widget/example/android/app/build.gradle
+++ b/packages/home_widget/example/android/app/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id "com.android.application"
-    id "kotlin-android"
     id "org.jetbrains.kotlin.plugin.compose"
     id "dev.flutter.flutter-gradle-plugin"
 }
@@ -36,10 +35,6 @@ android {
         targetCompatibility JavaVersion.VERSION_21
     }
 
-    kotlin {
-        jvmToolchain(21)
-    }
-
     lintOptions {
         disable 'InvalidPackage'
     }
@@ -73,6 +68,13 @@ android {
         }
     }
     namespace 'es.antonborri.home_widget_example'
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(JavaVersion.VERSION_21.toString())
+    }
+    jvmToolchain(21)
 }
 
 flutter {

--- a/packages/home_widget/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/home_widget/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/packages/home_widget/example/android/settings.gradle
+++ b/packages/home_widget/example/android/settings.gradle
@@ -18,9 +18,9 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.6.0" apply false
-    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
-    id "org.jetbrains.kotlin.plugin.compose" version "2.1.0" apply false
+    id "com.android.application" version "8.11.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
+    id "org.jetbrains.kotlin.plugin.compose" version "2.2.20" apply false
 }
 
 include ":app"

--- a/packages/home_widget/example/ios/Podfile
+++ b/packages/home_widget/example/ios/Podfile
@@ -43,8 +43,6 @@ target 'Runner' do
     use_frameworks!
     use_modular_headers!
     inherit! :search_paths
-
-    pod 'home_widget', :path => '.symlinks/plugins/home_widget/ios'
   end
 end
 

--- a/packages/home_widget/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/home_widget/example/ios/Runner.xcodeproj/project.pbxproj
@@ -110,7 +110,6 @@
 		E83E2772F8C2648F6A4B8430 /* Pods-HomeWidgetExampleExtension.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HomeWidgetExampleExtension.profile.xcconfig"; path = "Target Support Files/Pods-HomeWidgetExampleExtension/Pods-HomeWidgetExampleExtension.profile.xcconfig"; sourceTree = "<group>"; };
 		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 		784666492D4C4C64000A1A5F /* FlutterFramework */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterFramework; path = Flutter/ephemeral/Packages/.packages/FlutterFramework; sourceTree = "<group>"; };
-		78DABEA22ED26510000E7860 /* home_widget */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = home_widget; path = ../../ios/home_widget; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -177,7 +176,6 @@
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
-				78DABEA22ED26510000E7860 /* home_widget */,
 				784666492D4C4C64000A1A5F /* FlutterFramework */,
 				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,

--- a/packages/home_widget/ios/home_widget/Package.swift
+++ b/packages/home_widget/ios/home_widget/Package.swift
@@ -1,7 +1,12 @@
 // swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
+import Foundation
 import PackageDescription
+
+let flutterFrameworkPath = ProcessInfo.processInfo.environment[
+  "FLUTTER_FRAMEWORK_SWIFT_PACKAGE_PATH"
+] ?? "../FlutterFramework"
 
 let package = Package(
   name: "home_widget",
@@ -12,7 +17,7 @@ let package = Package(
     .library(name: "home-widget", targets: ["home_widget"])
   ],
   dependencies: [
-    .package(name: "FlutterFramework", path: "../FlutterFramework")
+    .package(name: "FlutterFramework", path: flutterFrameworkPath)
   ],
   targets: [
     .target(


### PR DESCRIPTION
# Feat: migrate examples to built-in Kotlin and iOS SPM path

# Description

This PR completes the Android built-in Kotlin migration for `home_widget` and aligns the package example with the iOS Swift Package Manager integration path.

On Android, `home_widget` no longer keeps the legacy Kotlin Gradle Plugin compatibility fallback. The plugin now relies on Flutter's built-in Kotlin path, and the old `android.builtInKotlin=false` / `android.newDsl=false` compatibility mode is no longer supported.

On iOS, the package example is updated to use the Swift Package Manager integration path instead of directly wiring `pod 'home_widget'` into the widget extension. The PR also updates repository examples, migration docs, setup docs, changelog entries, and CI guardrails so the documented setup matches the current implementation.

Validated with:
- `melos test`
- `flutter build apk --release` in `packages/home_widget/example`
- `flutter build ios --release --no-codesign` in `packages/home_widget/example`
- `flutter build apk --release` in `examples/configurable_widget`

## Checklist

- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added code (documentation) comments where necessary.
- [x] I have updated/added relevant examples in `example` or documentation.

## Breaking Change?

- [x] Yes, this PR is a breaking change.
- [ ] No, this PR is not a breaking change.

### Migration instructions

To migrate from the current release:

1. Remove `android.builtInKotlin=false` and `android.newDsl=false` from your Android `gradle.properties` if they are still present.
2. Make sure your project uses a modern Flutter/Android toolchain compatible with built-in Kotlin support, including Flutter 3.44+.
3. Rebuild your Android app and widget modules and verify they compile without relying on the legacy Kotlin Gradle Plugin fallback.
4. If your app still depends on third-party Flutter plugins that have not migrated to built-in Kotlin yet, Flutter may temporarily re-add legacy flags during local builds. Those plugins need to be updated separately.

## Related Issues

None.