### PR TITLE
fix: Move Android SharedPreferences IO off the main thread to prevent ANR

### DIFF
--- a/packages/home_widget/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetPlugin.kt
+++ b/packages/home_widget/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetPlugin.kt
@@ -18,6 +18,12 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /** HomeWidgetPlugin */
 class HomeWidgetPlugin :
@@ -33,6 +39,9 @@ class HomeWidgetPlugin :
   private var activity: Activity? = null
   private var receiver: BroadcastReceiver? = null
   private val doubleLongPrefix: String = "home_widget.double."
+
+  private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+  private val ioDispatcher = Dispatchers.IO.limitedParallelism(1)
 
   override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
     channel = MethodChannel(flutterPluginBinding.binaryMessenger, "home_widget")
@@ -59,18 +68,23 @@ class HomeWidgetPlugin :
               is Double -> prefs.putLong(id, java.lang.Double.doubleToRawLongBits(data))
               is Int -> prefs.putInt(id, data)
               is Long -> prefs.putLong(id, data)
-              else ->
-                  result.error(
-                      "-10",
-                      "Invalid Type ${data!!::class.java.simpleName}. Supported types are Boolean, Float, String, Double, Long",
-                      IllegalArgumentException(),
-                  )
+              else -> {
+                result.error(
+                    "-10",
+                    "Invalid Type ${data!!::class.java.simpleName}. Supported types are Boolean, Float, String, Double, Long",
+                    IllegalArgumentException(),
+                )
+                return
+              }
             }
           } else {
             prefs.remove(id)
             prefs.remove("$doubleLongPrefix$id")
           }
-          result.success(prefs.commit())
+          coroutineScope.launch {
+            val committed = withContext(ioDispatcher) { prefs.commit() }
+            result.success(committed)
+          }
         } else {
           result.error(
               "-1",
@@ -84,13 +98,17 @@ class HomeWidgetPlugin :
           val id = call.argument<String>("id")
           val defaultValue = call.argument<Any>("defaultValue")
 
-          val prefs = context.getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE)
-
-          val value = prefs.all[id] ?: defaultValue
-
-          if (value is Long && prefs.getBoolean("$doubleLongPrefix$id", false)) {
-            result.success(java.lang.Double.longBitsToDouble(value))
-          } else {
+          coroutineScope.launch {
+            val value =
+                withContext(ioDispatcher) {
+                  val prefs = context.getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE)
+                  val stored = prefs.all[id] ?: defaultValue
+                  if (stored is Long && prefs.getBoolean("$doubleLongPrefix$id", false)) {
+                    java.lang.Double.longBitsToDouble(stored)
+                  } else {
+                    stored
+                  }
+                }
             result.success(value)
           }
         } else {
@@ -264,6 +282,7 @@ class HomeWidgetPlugin :
 
   override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
     channel.setMethodCallHandler(null)
+    coroutineScope.cancel()
   }
 
   companion object {


### PR DESCRIPTION
# Description

On Android, `HomeWidget.saveWidgetData` persisted data by calling `SharedPreferences.Editor.commit()` directly inside `onMethodCall`, which runs on the platform (main) thread. `commit()` performs a synchronous `fsync`, so on slow storage it blocks the UI thread and triggers ANRs. This is exactly the stack reported in #401:

```
at android.app.SharedPreferencesImpl$EditorImpl.commit(SharedPreferencesImpl.java:604)
at es.antonborri.home_widget.HomeWidgetPlugin.onMethodCall(HomeWidgetPlugin.kt)
```

This PR moves the blocking `SharedPreferences` disk IO off the platform thread:

- `saveWidgetData` now runs `commit()` off the platform thread and replies once the write finishes. The reply is still sent only **after** the write completes, so an awaited `saveWidgetData` Future continues to guarantee the data has been persisted — the existing save-then-read ordering (and the integration tests that rely on it) keep working.
- `getWidgetData` resolves its value off the platform thread as well, since the first read loads the backing file from disk.
- The disk IO runs on `Dispatchers.IO.limitedParallelism(1)`, i.e. a single-threaded view of the IO pool. This keeps the previous behaviour where operations were serialized in call order (so concurrent/non-awaited reads and writes can't reorder), while no longer blocking the platform thread.
- Work is launched from a plugin-scoped `CoroutineScope(SupervisorJob() + Dispatchers.Main)` that is cancelled in `onDetachedFromEngine`. `kotlinx-coroutines-android` is already a dependency of the plugin.

While restructuring the `saveWidgetData` branch I also fixed a latent double-reply: for an unsupported data type the handler called `result.error(...)` and then still fell through to `result.success(prefs.commit())`, submitting two replies for one call. The unsupported-type branch now `return`s after `result.error(...)`. This removes one cause of the "Reply already submitted" crash tracked in #265.

## Checklist

- [-] I have updated/added tests for ALL new/updated/fixed functionality.
<!-- The existing Android integration tests (example/integration_test/android_test.dart) exercise the saveWidgetData/getWidgetData round-trip and still pass. A test asserting "the platform thread was not blocked" would be timing-based and flaky, so none was added. -->
- [x] I have updated/added relevant documentation and added code (documentation) comments where necessary.
- [-] I have updated/added relevant examples in `example` or documentation.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

## Related Issues

Closes #401
