### PR TITLE
fix: Migrate Plugin to Built-in Kotlin

### DIFF
--- a/packages/home_widget/android/build.gradle
+++ b/packages/home_widget/android/build.gradle
@@ -27,9 +27,6 @@ def builtInKotlinProperty = project.findProperty('android.builtInKotlin') ?: roo
 def useBuiltInKotlin = isAgp9OrAbove && (builtInKotlinProperty == null ? true : builtInKotlinProperty.toString().toBoolean())
 
 apply plugin: 'com.android.library'
-if (!useBuiltInKotlin) {
-    apply plugin: 'kotlin-android'
-}
 
 android {
     // Conditional for compatibility with AGP <4.2.
@@ -51,9 +48,9 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
         sourceCompatibility JavaVersion.VERSION_1_8
     }
-    if (!useBuiltInKotlin) {
-        kotlinOptions {
-            jvmTarget = "1.8"
+    kotlin {
+        compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
         }
     }
 }

--- a/packages/home_widget/android/build.gradle
+++ b/packages/home_widget/android/build.gradle
@@ -48,10 +48,11 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
         sourceCompatibility JavaVersion.VERSION_1_8
     }
-    kotlin {
-        compilerOptions {
-            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
-        }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 

--- a/packages/home_widget/android/gradle.properties
+++ b/packages/home_widget/android/gradle.properties
@@ -2,3 +2,5 @@ org.gradle.jvmargs=-Xmx1536M
 android.enableR8=true
 android.useAndroidX=true
 android.enableJetifier=true
+android.newDsl=false
+android.builtInKotlin=false


### PR DESCRIPTION
fix: Migrate Plugin to Built-in Kotlin

# Description
Starting with Android Gradle Plugin (AGP) 9.0, support for applying the Kotlin Gradle Plugin (KGP) has been removed. Because this plugin applies KGP, it causes a compilation error that prevents my app from building. Here is an example of the error, Issue #181383.

Flutter has temporarily added support to allow KGP while apps and plugins migrate to AGP 9.0+, but this support will be removed in a future version of Flutter.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation and added code (documentation) comments where necessary.
- [ ] I have updated/added relevant examples in `example` or documentation.


## Breaking Change?
<!--
Would your PR require home_widget users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

## Related Issues
Closes #421 

<!-- Links -->
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/abausg/home_widget/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->