### PR TITLE
feat(android): Opt-in expedited WorkManager execution for background callbacks

### DIFF
--- a/packages/home_widget/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetBackgroundReceiver.kt
+++ b/packages/home_widget/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetBackgroundReceiver.kt
@@ -10,6 +10,7 @@ class HomeWidgetBackgroundReceiver : BroadcastReceiver() {
     val flutterLoader = FlutterInjector.instance().flutterLoader()
     flutterLoader.startInitialization(context)
     flutterLoader.ensureInitializationComplete(context, null)
-    HomeWidgetBackgroundWorker.enqueueWork(context, intent)
+    val expedited = intent.getBooleanExtra(HomeWidgetBackgroundIntent.EXTRA_IS_EXPEDITED, false)
+    HomeWidgetBackgroundWorker.enqueueWork(context, intent, expedited)
   }
 }

--- a/packages/home_widget/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetBackgroundWorker.kt
+++ b/packages/home_widget/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetBackgroundWorker.kt
@@ -9,6 +9,7 @@ import androidx.work.CoroutineWorker
 import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import io.flutter.FlutterInjector
@@ -111,11 +112,17 @@ class HomeWidgetBackgroundWorker(private val context: Context, workerParams: Wor
     private val serviceStarted = AtomicBoolean(false)
     private val mainHandler = Handler(Looper.getMainLooper())
 
-    fun enqueueWork(context: Context, work: Intent) {
+    fun enqueueWork(context: Context, work: Intent, expedited: Boolean = false) {
       val data = Data.Builder().putString(DATA_KEY, work.data?.toString() ?: "").build()
 
-      val workRequest =
-          OneTimeWorkRequestBuilder<HomeWidgetBackgroundWorker>().setInputData(data).build()
+      val workRequestBuilder = OneTimeWorkRequestBuilder<HomeWidgetBackgroundWorker>()
+          .setInputData(data)
+
+      if (expedited) {
+        workRequestBuilder.setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+      }
+
+      val workRequest = workRequestBuilder.build()
 
       WorkManager.getInstance(context)
           .enqueueUniqueWork(UNIQUE_WORK_NAME, ExistingWorkPolicy.APPEND, workRequest)

--- a/packages/home_widget/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetBackgroundWorker.kt
+++ b/packages/home_widget/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetBackgroundWorker.kt
@@ -2,6 +2,7 @@ package es.antonborri.home_widget
 
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
@@ -112,13 +113,16 @@ class HomeWidgetBackgroundWorker(private val context: Context, workerParams: Wor
     private val serviceStarted = AtomicBoolean(false)
     private val mainHandler = Handler(Looper.getMainLooper())
 
+    @JvmOverloads
     fun enqueueWork(context: Context, work: Intent, expedited: Boolean = false) {
       val data = Data.Builder().putString(DATA_KEY, work.data?.toString() ?: "").build()
 
       val workRequestBuilder = OneTimeWorkRequestBuilder<HomeWidgetBackgroundWorker>()
           .setInputData(data)
 
-      if (expedited) {
+      // Expedited work on API < 31 falls back to a foreground service, which requires
+      // getForegroundInfo() — CoroutineWorker's default throws. Only expedite on 31+.
+      if (expedited && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
         workRequestBuilder.setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
       }
 

--- a/packages/home_widget/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetIntent.kt
+++ b/packages/home_widget/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetIntent.kt
@@ -53,11 +53,13 @@ inline fun <reified T : Activity> actionStartActivity(context: Context, uri: Uri
 
 object HomeWidgetBackgroundIntent {
   private const val HOME_WIDGET_BACKGROUND_ACTION = "es.antonborri.home_widget.action.BACKGROUND"
+  const val EXTRA_IS_EXPEDITED = "es.antonborri.home_widget.extra.IS_EXPEDITED"
 
-  fun getBroadcast(context: Context, uri: Uri? = null): PendingIntent {
+  fun getBroadcast(context: Context, uri: Uri? = null, expedited: Boolean = false): PendingIntent {
     val intent = Intent(context, HomeWidgetBackgroundReceiver::class.java)
     intent.data = uri
     intent.action = HOME_WIDGET_BACKGROUND_ACTION
+    intent.putExtra(EXTRA_IS_EXPEDITED, expedited)
 
     var flags = PendingIntent.FLAG_UPDATE_CURRENT
     if (Build.VERSION.SDK_INT >= 23) {

--- a/packages/home_widget/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetIntent.kt
+++ b/packages/home_widget/android/src/main/kotlin/es/antonborri/home_widget/HomeWidgetIntent.kt
@@ -55,6 +55,7 @@ object HomeWidgetBackgroundIntent {
   private const val HOME_WIDGET_BACKGROUND_ACTION = "es.antonborri.home_widget.action.BACKGROUND"
   const val EXTRA_IS_EXPEDITED = "es.antonborri.home_widget.extra.IS_EXPEDITED"
 
+  @JvmOverloads
   fun getBroadcast(context: Context, uri: Uri? = null, expedited: Boolean = false): PendingIntent {
     val intent = Intent(context, HomeWidgetBackgroundReceiver::class.java)
     intent.data = uri
@@ -66,6 +67,9 @@ object HomeWidgetBackgroundIntent {
       flags = flags or PendingIntent.FLAG_IMMUTABLE
     }
 
-    return PendingIntent.getBroadcast(context, 0, intent, flags)
+    // Extras are not part of a PendingIntent's identity; fold the expedited flag into
+    // the request code so expedited and non-expedited registrations don't collide.
+    val requestCode = if (expedited) 1 else 0
+    return PendingIntent.getBroadcast(context, requestCode, intent, flags)
   }
 }


### PR DESCRIPTION
# Description

Follow-up to #377, where you asked for the Android changes to be split out and motivated separately — this PR contains only that change.

## Problem

`HomeWidgetBackgroundWorker.enqueueWork()` schedules background callbacks as regular `OneTimeWorkRequest`s. WorkManager treats these as deferrable: under Doze/battery-saver/App Standby buckets, execution of a widget interaction (e.g. tapping a checkbox on a home-screen widget) can be delayed by seconds or longer. For interactive widgets the user is watching the widget while the tap is processed, so the delay reads as the widget being broken.

## Change

Adds an opt-in `EXTRA_IS_EXPEDITED` boolean on `HomeWidgetBackgroundIntent`. When set, the work request is built with `setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)`, so taps run promptly while the app has expedited quota and degrade gracefully to normal scheduling when quota is exhausted. Default is `false` — existing behavior is unchanged unless a caller opts in.

We've been running this in production in a task-journal app (Bullet) for widget check-off interactions since late 2025.

🤖 Generated with [Claude Code](https://claude.com/claude-code)