### PR TITLE
fix(ios): Properly serialize arrays of Codable objects in widget config

### DIFF
--- a/packages/home_widget/ios/home_widget/Sources/home_widget/HomeWidgetPlugin.swift
+++ b/packages/home_widget/ios/home_widget/Sources/home_widget/HomeWidgetPlugin.swift
@@ -313,9 +313,39 @@ public class HomeWidgetPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
                       case let dataValue as Data:
                         configuration[propertyName] = FlutterStandardTypedData(bytes: dataValue)
 
+                      // Handle arrays of Codable types (must come BEFORE generic array case)
                       case let arrayValue as [Any]:
-                        configuration[propertyName] = arrayValue
-
+                        // Try to encode array elements as Codable
+                        let encoder = JSONEncoder()
+                        var encodedArray: [[String: Any]] = []
+                        var allEncodedSuccessfully = true
+                        
+                        for element in arrayValue {
+                          if let codableElement = element as? (any Codable) {
+                            do {
+                              let data = try encoder.encode(codableElement)
+                              if let jsonObject = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
+                                encodedArray.append(jsonObject)
+                              } else {
+                                allEncodedSuccessfully = false
+                                break
+                              }
+                            } catch {
+                              allEncodedSuccessfully = false
+                              break
+                            }
+                          } else {
+                            allEncodedSuccessfully = false
+                            break
+                          }
+                        }
+                        
+                        if allEncodedSuccessfully && !encodedArray.isEmpty {
+                          configuration[propertyName] = encodedArray
+                        } else {
+                          // Fallback to string conversion if encoding fails
+                          configuration[propertyName] = arrayValue.map { "\($0)" }
+                        }
                       case let dictionaryValue as [String: Any]:
                         configuration[propertyName] = dictionaryValue
 

--- a/packages/home_widget/ios/home_widget/Sources/home_widget/HomeWidgetPlugin.swift
+++ b/packages/home_widget/ios/home_widget/Sources/home_widget/HomeWidgetPlugin.swift
@@ -321,6 +321,8 @@ public class HomeWidgetPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
                         let encoder = JSONEncoder()
                         configuration[propertyName] = arrayValue.map { element -> Any in
                           switch element {
+                          case let null as NSNull:
+                            return null
                           case let number as NSNumber:
                             return number
                           case let string as String:

--- a/packages/home_widget/ios/home_widget/Sources/home_widget/HomeWidgetPlugin.swift
+++ b/packages/home_widget/ios/home_widget/Sources/home_widget/HomeWidgetPlugin.swift
@@ -313,38 +313,32 @@ public class HomeWidgetPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
                       case let dataValue as Data:
                         configuration[propertyName] = FlutterStandardTypedData(bytes: dataValue)
 
-                      // Handle arrays of Codable types (must come BEFORE generic array case)
+                      // Handle arrays element-wise (must come BEFORE generic array case).
+                      // JSON-native elements pass through unchanged; complex Codable
+                      // elements are encoded to JSON objects; anything else falls back
+                      // to its string representation individually.
                       case let arrayValue as [Any]:
-                        // Try to encode array elements as Codable
                         let encoder = JSONEncoder()
-                        var encodedArray: [[String: Any]] = []
-                        var allEncodedSuccessfully = true
-                        
-                        for element in arrayValue {
-                          if let codableElement = element as? (any Codable) {
-                            do {
-                              let data = try encoder.encode(codableElement)
-                              if let jsonObject = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
-                                encodedArray.append(jsonObject)
-                              } else {
-                                allEncodedSuccessfully = false
-                                break
-                              }
-                            } catch {
-                              allEncodedSuccessfully = false
-                              break
+                        configuration[propertyName] = arrayValue.map { element -> Any in
+                          switch element {
+                          case let number as NSNumber:
+                            return number
+                          case let string as String:
+                            return string
+                          case let dictionary as [String: Any]:
+                            return dictionary
+                          case let nested as [Any]:
+                            return nested
+                          default:
+                            if let codableElement = element as? (any Codable),
+                              let data = try? encoder.encode(codableElement),
+                              let jsonObject = try? JSONSerialization.jsonObject(
+                                with: data, options: [.fragmentsAllowed])
+                            {
+                              return jsonObject
                             }
-                          } else {
-                            allEncodedSuccessfully = false
-                            break
+                            return "\(element)"
                           }
-                        }
-                        
-                        if allEncodedSuccessfully && !encodedArray.isEmpty {
-                          configuration[propertyName] = encodedArray
-                        } else {
-                          // Fallback to string conversion if encoding fails
-                          configuration[propertyName] = arrayValue.map { "\($0)" }
                         }
                       case let dictionaryValue as [String: Any]:
                         configuration[propertyName] = dictionaryValue


### PR DESCRIPTION
# Description

Supersedes #377, rebased onto current `main` and now containing **only** the iOS fix — the unrelated Android change has been split out into #435 with its own motivation, as requested there.

Fixes a serialization bug in `HomeWidgetPlugin.swift` where arrays of `Codable` objects (e.g. `[EntryTypeEntity]`) were not properly encoded when extracting widget configuration via `getInstalledWidgets()`. The generic array case matched before the Codable-aware case, so elements came through as opaque descriptions instead of JSON dictionaries. Each element is now encoded to a JSON dictionary, with a string fallback for elements that fail to encode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)