### PR TITLE
build!: Updated gradle and build version

### DIFF
--- a/packages/home_widget/android/build.gradle
+++ b/packages/home_widget/android/build.gradle
@@ -2,14 +2,14 @@ group 'es.antonborri.home_widget'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.9.0'
+    ext.kotlin_version = '2.1.0'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.2'
+        classpath 'com.android.tools.build:gradle:8.7.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -32,35 +32,36 @@ if (!useBuiltInKotlin) {
 }
 
 android {
-    // Conditional for compatibility with AGP <4.2.
-    if (project.android.hasProperty("namespace")) {
-        namespace 'es.antonborri.home_widget'
-    }
+    namespace 'es.antonborri.home_widget'
     compileSdk 35
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
+
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 21
     }
-    lintOptions {
-        disable 'InvalidPackage'
+
+    lint {
+        disable += 'InvalidPackage'
     }
+
     compileOptions {
-        targetCompatibility JavaVersion.VERSION_1_8
-        sourceCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
+
     if (!useBuiltInKotlin) {
         kotlinOptions {
-            jvmTarget = "1.8"
+            jvmTarget = "17"
         }
     }
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "androidx.glance:glance-appwidget:1.1.1"
-    implementation "androidx.work:work-runtime-ktx:2.11.2"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2"
+    implementation "androidx.work:work-runtime-ktx:2.10.0"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0"
 }

--- a/packages/home_widget/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/home_widget/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Oct 13 13:45:37 IST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
build: update Android build configurations, Kotlin version, and Gradle dependencies

# Description

This PR updates the Android build configurations and tooling dependencies across the package to align with updated modern Android development standards.

### Summary of changes:
* **Gradle Wrapper:** Updated distribution URL to Gradle `9.4.1-all.zip` (from `8.1-bin.zip`).
* **Kotlin:** Updated Kotlin version to `2.1.0` (from `1.9.0`), replaced `kotlin-stdlib-jdk8` dependency with standard `kotlin-stdlib`, and set `jvmTarget` to `17` (from `1.8`).
* **Android Gradle Plugin (AGP):** Upgraded `com.android.tools.build:gradle` to `8.7.3` (from `8.1.2`).
* **SDK & Java Compatibility:** Raised `minSdkVersion` to `21` (from `16`) and bumped Java compatibility options (`sourceCompatibility` and `targetCompatibility`) to `JavaVersion.VERSION_17` (from `VERSION_1_8`).
* **Namespace & Lint:** Simplified namespace declaration (`es.antonborri.home_widget`) by removing legacy conditional checks for AGP < 4.2 and migrated DSL from `lintOptions` to `lint`.
* **Dependencies:** Adjusted AndroidX Work Manager (`work-runtime-ktx` to `2.10.0`) and Coroutines (`kotlinx-coroutines-android` to `1.9.0`).

## Checklist

- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation and added code (documentation) comments where necessary.
- [ ] I have updated/added relevant examples in `example` or documentation.


## Breaking Change?

- [x] Yes, this PR is a breaking change.
- [ ] No, this PR is not a breaking change.

### Migration instructions

* **Minimum SDK Version:** The minimum supported Android SDK version for apps using `home_widget` is now **21** (Android 5.0 Lollipop). Ensure your app's `minSdkVersion` in `android/app/build.gradle` is set to `21` or higher.
* **Java Target:** Projects using this package must target Java 17 (`JavaVersion.VERSION_17` / JVM target `17`).
